### PR TITLE
Allow the use of a 'page' parameter for pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ users.list.fetch.before(function(req, res, context) {
 
 ### Pagination
 
-List routes support pagination via `offset` and `count` query parameters.  Find metadata about pagination and number of results in the `Content-Range` response header.
+List routes support pagination via `offset` or `page` and `count` query parameters.  Find metadata about pagination and number of results in the `Content-Range` response header.
 
 ```bash
 # get the third page of results

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -25,8 +25,9 @@ List.prototype.fetch = function(req, res, context) {
 
 	var defaultCount = 100;
 
-	var offset = +context.offset || +req.query.offset || 0;
 	var count = +context.count || +req.query.count || defaultCount;
+	var offset = +context.offset || +req.query.offset || 0;
+    offset += context.page*count || req.query.page*count || 0;
 
 	if (count > 1000) count = 1000;
 	if (count < 0) count = defaultCount;


### PR DESCRIPTION
I was finding that some client-side APIs (such as BackbonePageable) expect the option to use a "page" parameter for pagination, not an "offset" parameter. I went ahead and added support for this because it was a pretty straight-forward change.
