### PR TITLE
Switch from "post" to "put" as the method for updating over rest.

### DIFF
--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -10,7 +10,7 @@ var Update = function(args) {
 util.inherits(Update, Base);
 
 Update.prototype.action = 'update';
-Update.prototype.method = 'post';
+Update.prototype.method = 'put';
 Update.prototype.plurality = 'singular';
 
 Update.prototype.fetch = function(req, res, context) {


### PR DESCRIPTION
Switch to the PUT method instead of POST for sending updates for rest models, which brings the API more in line with the HTTP 1.1 spec:
http://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol#Request_methods
