### PR TITLE
Fix the ability to pass 'actions' into epilogue.resource

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,8 @@ var epilogue = {
 		var resource = new Resource({
 			app: this.app,
 			model: args.model,
-			endpoints: endpoints
+			endpoints: endpoints,
+			actions: args.actions
 		});
 
 		return resource;


### PR DESCRIPTION
Actions that you supply to the `.resource` method were not being passed on to the constructor for `Resource` objects, which meant this feature didn't work as documented. Made a small tweak to fix this behavior.

I would have updated the tests to check for this, but I couldn't get your test suite to run. I did test it in my own project however, both in the case where no actions are passed, and when a list of actions is passed.
