### PR TITLE
Fix the value of the content-range header for endpoints that have criteria

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -45,7 +45,7 @@ List.prototype.fetch = function(req, res, context) {
 				return context.stop();
 			}
 			context.instance = instance;
-			model.count()
+			model.count({where: options.where})
 				.success(function(count) {
 					var start = offset;
 					var end = start + instance.length - 1;


### PR DESCRIPTION
Right now the content range returns a count of all items, not just items that match the criteria supplied, which makes it somewhat useless for pagination of filtered lists. Pull request fixes the issue.
