### PR TITLE
add support for a generic query

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -19,7 +19,8 @@ List.prototype.fetch = function(req, res, context) {
   var criteria = context.criteria || {};
   var include = this.include;
   var includeAttributes = this.includeAttributes;
-  
+  var Sequelize = this.resource.sequelize;
+
   endpoint.attributes.forEach(function(attribute) {
     criteria[attribute] = req.params[attribute];
   });
@@ -39,6 +40,20 @@ List.prototype.fetch = function(req, res, context) {
       Object.keys(model.rawAttributes).filter(function(attr) {
         return includeAttributes.indexOf(attr);
       });
+  }
+
+  if (req.query.q) {
+    var search = [];
+    Object.keys(model.rawAttributes).forEach(function(attr) {
+      var item = {};
+      item[attr] = { like: '%' + req.query.q + '%' };
+      search.push(item);
+    });
+
+    if (Object.keys(criteria).length)
+      criteria = Sequelize.and(criteria, Sequelize.or.apply(null, search));
+    else
+      criteria = Sequelize.or.apply(null, search);
   }
 
   if (Object.keys(criteria).length) {

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -5,6 +5,7 @@ var Controllers = require('./Controllers');
 var Resource = function(args) {
   args = args || {};
   this.app = args.app;
+  this.sequelize = args.sequelize;
 
   if (!args.model)
     throw new Error("resource needs a model");

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,8 +9,11 @@ var epilogue = {
     args = args || {};
     if (!args.app)
       throw new Error("please specify an app");
+    if (!args.sequelize)
+      throw new Error("please specify a sequelize instance");
 
     this.app = args.app;
+    this.sequelize = args.sequelize;
     this.base = args.base || '';
     if (args.updateMethod) {
       var method = args.updateMethod.toLowerCase();
@@ -32,6 +35,7 @@ var epilogue = {
 
     var resource = new Resource({
       app: this.app,
+      sequelize: this.sequelize,
       model: args.model,
       endpoints: endpoints,
       actions: args.actions,

--- a/package.json
+++ b/package.json
@@ -16,11 +16,11 @@
   "devDependencies": {
     "sqlite3": "~2.2.0",
     "request": "~2.34.0",
-    "sequelize": ">=1.7.0",
     "express": ">=3.0.0",
     "mocha": ">=1.17.0",
     "chai": ">= 1.9.0",
-    "jshint": ">=2.4.2"
+    "jshint": ">=2.4.2",
+    "sequelize": "~1.7.0-rc6"
   },
   "dependencies": {
     "async": "~0.2.10",

--- a/tests/resource.associations.js
+++ b/tests/resource.associations.js
@@ -48,7 +48,10 @@ describe('Resource(associations)', function() {
         test.app.use(express.json());
         test.app.use(express.urlencoded());
 
-        rest.initialize({ app: test.app });
+        rest.initialize({
+          app: test.app,
+          sequelize: Sequelize
+        });
         rest.resource({
           model: test.User,
           include: [test.Address],

--- a/tests/resource.basic.js
+++ b/tests/resource.basic.js
@@ -34,7 +34,10 @@ describe('Resource(basic)', function() {
         test.app.use(express.json());
         test.app.use(express.urlencoded());
 
-        rest.initialize({ app: test.app });
+        rest.initialize({
+          app: test.app,
+          sequelize: Sequelize
+        });
         rest.resource({
           model: test.User,
           endpoints: ['/users', '/users/:id']
@@ -226,6 +229,25 @@ describe('Resource(basic)', function() {
         var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
         expect(records).to.eql(test.userlist.slice(1,3));
         expect(response.headers['content-range']).to.equal('items 1-2/5');
+        done();
+      });
+    });
+
+    it('should support a generic query string', function(done) {
+      request.get({ url: test.baseUrl + '/users?q=ll' }, function(err, response, body) {
+        expect(response.statusCode).to.equal(200);
+        var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+        expect(records).to.eql([{ username: "william", email: "william@gmail.com" }]);
+        done();
+      });
+    });
+
+    it('should support a generic query string as well as other criteria', function(done) {
+      request.get({ url: test.baseUrl + '/users?q=gmail&offset=1&count=2' }, function(err, response, body) {
+        expect(response.statusCode).to.equal(200);
+        var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+        expect(records).to.eql([{ username: "james", email: "james@gmail.com" },
+                                { username: "henry", email: "henry@gmail.com" }]);
         done();
       });
     });

--- a/tests/resource.milestones.js
+++ b/tests/resource.milestones.js
@@ -34,7 +34,10 @@ describe('Resource(milestones)', function() {
         test.app.use(express.json());
         test.app.use(express.urlencoded());
 
-        rest.initialize({ app: test.app });
+        rest.initialize({
+          app: test.app,
+          sequelize: Sequelize
+        });
         test.userResource = rest.resource({
           model: test.User,
           endpoints: ['/users', '/users/:id']


### PR DESCRIPTION
This adds the option to pass a 'q' query item to your rest controller to easily search through all fields. It could probably be improved to omit the 'id' field, but I thought it'd be better to start to conversation here.

In order to support using Sequelize.or and Sequelize.and, it is now required to pass your instance of Sequelize in to the init function for epilogue. This removes the need for a dependency on sequelize in epilogue and paves the way for deeper sequelize integration in the future
