### PR TITLE
fix queries with empty where, which result in generating sql with WHERE 1=1

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -34,6 +34,7 @@ List.prototype.fetch = function(req, res, context) {
   if (count < 0) count = defaultCount;
     
   var options = { offset: offset, limit: count };
+  var countOptions = {};
   if (include.length) {
     options.include = include;
     options.attributes =
@@ -58,6 +59,7 @@ List.prototype.fetch = function(req, res, context) {
 
   if (Object.keys(criteria).length) {
     options.where = criteria;
+    countOptions.where = criteria;
   }
 
   model
@@ -71,7 +73,7 @@ List.prototype.fetch = function(req, res, context) {
 
       context.instance = instance;
       model
-        .count({where: options.where})
+        .count(countOptions)
         .success(function(count) {
           var start = offset;
           var end = start + instance.length - 1;


### PR DESCRIPTION
I'm not sure how to actually test this one, since we don't return any means for checking generated SQL, however, if you do a list with no criteria the resulting .count called will try to query with an empty queryset for the "where" key and the output will look like:

```
SELECT COUNT(*) as `count` FROM `users` WHERE 1=1;
```
