### PR TITLE
Support modifying error data before sending response.

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -50,6 +50,10 @@ Controller.prototype.error = function(req, res) {
 };
 
 Controller.prototype.send = function(req, res, context) {
+  if (context.error !== undefined) {
+    res.json(context.error);
+    return context.continue();
+  }
   res.json(context.instance);
   return context.continue();
 };
@@ -72,6 +76,7 @@ Controller.prototype._control = function(req, res) {
     instance: undefined,
     criteria: {},
     attributes: {},
+    error: undefined,
     continue: function() { _callback(); },
     stop: function() { _callback(true); },
     skip: function() { skip = true; _callback(); }

--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -15,6 +15,10 @@ Create.prototype.method = 'post';
 Create.prototype.plurality = 'plural';
 
 Create.prototype.write = function(req, res, context) {
+  if (context.error !== undefined) {
+    return context.skip();
+  }
+
   var model = this.model;
   _(context.attributes).extend(_(req.body).clone());
 
@@ -41,8 +45,9 @@ Create.prototype.write = function(req, res, context) {
         context.continue();
       })
       .error(function(err) {
-        res.json(500, { error: err });
-        context.stop();
+        context.error = { error: err };
+        res.status(500);
+        return context.skip();
       });
   };
 
@@ -53,20 +58,23 @@ Create.prototype.write = function(req, res, context) {
     validation
       .success(function(err) {
         if (err) {
-          res.json(400, { error: err });
-          context.stop();
+          res.status(400);
+          context.error = { error: err };
+          context.continue();
         } else {
           save();
         }
       })
       .error(function(err) {
-        res.json(500, { error: err });
-        context.stop();
+        res.status(500);
+        context.error = { error: err };
+        context.continue();
       });
   } else if (validation && typeof validation === 'object') {
     // sequelize 1.x error
-    res.json(400, { error: validation });
-    context.stop();
+    res.status(400);
+    context.error = { error: validation };
+    context.continue();
   } else {
     // sequelize 1.x success
     save();

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -29,20 +29,26 @@ Update.prototype.fetch = function(req, res, context) {
         // not sure this was ever reached even
         // return yield([404, { error: "not found" }]);
 
-        res.json(404, { error: "not found" });
-        return context.stop();
+        res.status(404);
+        context.error = { error: "not found" };
+        return context.continue();
       }
 
       context.instance = instance;
       return context.continue();
     })
     .error(function(err) {
-      res.json(500, { error: err });
-      return context.stop();
+      res.status(500);
+      context.error = { error: err };
+      return context.continue();
     });
 };
 
 Update.prototype.write = function(req, res, context) {
+  if (context.error !== undefined) {
+    return context.skip();
+  }
+
   var instance = context.instance;
   instance
     .destroy(instance)
@@ -51,8 +57,9 @@ Update.prototype.write = function(req, res, context) {
       return context.continue();
     })
     .error(function(err) {
-      res.json(500, { error: err });
-      return context.stop();
+      res.status(500);
+      context.error = { error: err };
+      return context.continue();
     });
 };
 

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -29,20 +29,26 @@ Update.prototype.fetch = function(req, res, context) {
     .find({ where: criteria })
     .success(function(instance) {
       if (!instance) {
-        res.json(404, { error: "not found" });
-        return context.stop();
+        res.status(404);
+        context.error = { error: "not found" };
+        return context.continue();
       }
       
       context.instance = instance;
       context.continue();
     })
     .error(function(err) {
-      res.json(500, { error: err });
-      context.stop();
+      res.status(500);
+      context.error = { error: err };
+      return context.continue();
     });
 };
 
 Update.prototype.write = function(req, res, context) {
+  if (context.error !== undefined) {
+    return context.skip();
+  }
+
   var instance = context.instance;
   _(context.attributes).extend(_(req.body).clone());
 
@@ -61,8 +67,9 @@ Update.prototype.write = function(req, res, context) {
         context.continue();
       })
       .error(function(err) {
-        res.json(500, { error: err });
-        context.stop();
+        res.status(500);
+        context.error = { error: err };
+        return context.continue();
       });
   };
 
@@ -74,20 +81,23 @@ Update.prototype.write = function(req, res, context) {
     validation
       .success(function(err) {
         if (err) {
-          res.json(400, { error: err });
-          context.stop();
+          res.status(400);
+          context.error = { error: err };
+          context.continue();
         } else {
           save();
         }
       })
       .error(function(err) {
-        res.json(500, { error: err });
-        context.stop();
+        res.status(500);
+        context.error = { error: err };
+        context.continue();
       });
   } else if (validation && typeof validation === 'object') {
     // sequelize 1.x error
-    res.json(400, { error: validation });
-    context.stop();
+    res.status(400);
+    context.error = { error: validation };
+    context.continue();
   } else {
     // sequelize 1.x success
     save();


### PR DESCRIPTION
This change enables users to customize the response when an error occurs via a send milestone. Additionally, the controller may now gracefully continue through all parts of its loop instead of abruptly exiting at the first sign of an error. The `error` field was added to the `context` object to facilitate passing the error message through all hooks. An example usage can be found in the updated unit test.
