### PR TITLE
Add support for validation hooks.

### DIFF
--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -51,34 +51,27 @@ Create.prototype.write = function(req, res, context) {
       });
   };
 
-  var validation = instance.validate();
-
-  if (validation && typeof validation.success === 'function') {
-    // sequelize 2.x
-    validation
-      .success(function(err) {
-        if (err) {
+  var validation = instance.hookValidate();
+  validation
+    .success(function(validatedInstance) {
+      instance = validatedInstance;
+      save();
+    })
+    .error(function(err) {
+      context.error = { error: err };
+      if (validation.fct) {
+        // sequelize 1.x
+        res.status(400);
+      } else {
+        // sequelize 2.x
+        if (err.hasOwnProperty('name') && err.name === 'SequelizeValidationError') {
           res.status(400);
-          context.error = { error: err };
-          context.continue();
         } else {
-          save();
+          res.status(500);
         }
-      })
-      .error(function(err) {
-        res.status(500);
-        context.error = { error: err };
-        context.continue();
-      });
-  } else if (validation && typeof validation === 'object') {
-    // sequelize 1.x error
-    res.status(400);
-    context.error = { error: validation };
-    context.continue();
-  } else {
-    // sequelize 1.x success
-    save();
-  }
+      }
+      context.continue();
+    });
 };
 
 module.exports = Create;

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -73,35 +73,27 @@ Update.prototype.write = function(req, res, context) {
       });
   };
 
-
-  var validation = instance.validate();
-
-  if (validation && typeof validation.success === 'function') {
-    // sequelize 2.x
-    validation
-      .success(function(err) {
-        if (err) {
+  var validation = instance.hookValidate();
+  validation
+    .success(function(validatedInstance) {
+      instance = validatedInstance;
+      save();
+    })
+    .error(function(err) {
+      context.error = { error: err };
+      if (validation.fct) {
+        // sequelize 1.x
+        res.status(400);
+      } else {
+        // sequelize 2.x
+        if (err.hasOwnProperty('name') && err.name === 'SequelizeValidationError') {
           res.status(400);
-          context.error = { error: err };
-          context.continue();
         } else {
-          save();
+          res.status(500);
         }
-      })
-      .error(function(err) {
-        res.status(500);
-        context.error = { error: err };
-        context.continue();
-      });
-  } else if (validation && typeof validation === 'object') {
-    // sequelize 1.x error
-    res.status(400);
-    context.error = { error: validation };
-    context.continue();
-  } else {
-    // sequelize 1.x success
-    save();
-  }
+      }
+      context.continue();
+    });
 };
 
 module.exports = Update;


### PR DESCRIPTION
Sequelize supports beforeValidate and afterValidate hooks to manipulate data before and after validation. Calling instance.validate() prevented those hooks from being executed. This uses instance.hookValidate() instead to allow those extra hooks to run. 