### PR TITLE
add ability to specify extra configuration in middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ module.exports = {
       }
     }
   }
-}
+};
 
 // my-app.js
 var rest = require('epilogue'),
@@ -117,6 +117,22 @@ var users = rest.resource({
 });
 
 users.use(restMiddleware);
+```
+
+Epilogue middleware also supports bundling in extra resource configuration by specifying
+an "extraConfiguration" member of the middleware like so:
+
+```
+// my-middleware.js
+module.exports = {
+  extraConfiguration: function(resource) {
+    // support delete for plural form of a resource
+    var app = resource.app;
+    app.del(resource.endpoints.plural, function(req, res) {
+      resource.controllers.delete._control(req, res);
+    });
+  }
+};
 ```
 
 ### Pagination

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -89,6 +89,9 @@ Resource.prototype.use = function(middleware) {
       });
     }
   });
+
+  if (_.has(middleware, 'extraConfiguration') && _.isFunction(middleware.extraConfiguration))
+    middleware.extraConfiguration(this);
 };
 
 module.exports = Resource;

--- a/tests/milestones/data/test-middleware-before-after.js
+++ b/tests/milestones/data/test-middleware-before-after.js
@@ -1,9 +1,13 @@
 'use strict';
 
 var TestMiddlewareBeforeAfter = {
-  results: {}
+  results: {},
+  extraConfiguration: function(resource) {
+    TestMiddlewareBeforeAfter.results.extraConfiguration = true;
+  }
 };
 
+TestMiddlewareBeforeAfter.results.extraConfiguration = false;
 var actions = ['create', 'list', 'read', 'update', 'delete'],
     milestones = ['start', 'auth', 'fetch', 'data', 'write', 'send', 'complete'];
 

--- a/tests/milestones/data/test-middleware.js
+++ b/tests/milestones/data/test-middleware.js
@@ -1,9 +1,13 @@
 'use strict';
 
 var TestMiddleware = {
-  results: {}
+  results: {},
+  extraConfiguration: function(resource) {
+    TestMiddleware.results.extraConfiguration = true;
+  }
 };
 
+TestMiddleware.results.extraConfiguration = false;
 var actions = ['create', 'list', 'read', 'update', 'delete'],
     milestones = ['start', 'auth', 'fetch', 'data', 'write', 'send', 'complete'];
 

--- a/tests/milestones/middleware.test.js
+++ b/tests/milestones/middleware.test.js
@@ -61,6 +61,8 @@ describe('Milestones(middleware)', function() {
         });
 
         test.userResource.use(middleware);
+        expect(middleware.results.extraConfiguration).to.be.true;
+
         done();
       });
 


### PR DESCRIPTION
Sometimes a user might need to provide extra configuration for a given resource. This allows the user to bundle that extra behavior directly in the middleware, along with other possible milestone behaviors
