### PR TITLE
milestone overloads should stack on top of existing behavior

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -88,7 +88,7 @@ Controller.prototype._control = function(req, res) {
       };
 
   Controller.hooks.forEach(function(hook) {
-    [hook + '_before', hook, hook + '_after'].forEach(function(key, i) {
+    [hook + '_before', hook, hook + '_after'].forEach(function(key) {
       var functions = self[key] instanceof Array ? self[key] : [self[key]];
       functions.forEach(function(f) {
         work.push(function(callback) {
@@ -122,7 +122,7 @@ Controller.prototype.milestone = function(name, callback) {
   if (!(this[name] instanceof Array))
     this[name] = [this[name]];
 
-  this[name].push(callback);
+  this[name].unshift(callback);
 };
 
 module.exports = Controller;

--- a/tests/milestones/milestones.test.js
+++ b/tests/milestones/milestones.test.js
@@ -47,6 +47,29 @@ describe('Milestones', function() {
 
   // TESTS
   describe('general behavior', function() {
+    it('should stack milestones', function(done) {
+      var results = [];
+      test.userResource.read.fetch(function(req, res, context) {
+        results.push(1);
+        context.continue();
+      });
+
+      test.userResource.read.fetch(function(req, res, context) {
+        results.push(2);
+        context.continue();
+      });
+
+      test.userResource.read.fetch(function(req, res, context) {
+        results.push(3);
+        context.continue();
+      });
+
+      request.get({ url: test.baseUrl + '/users/1' }, function(err, response, body) {
+        expect(results).to.eql([3, 2, 1]);
+        done();
+      });
+    });
+
     it('should skip the main action if context.skip is called in before hook', function(done) {
       var SkipMiddleware = {
         results: {
@@ -83,9 +106,9 @@ describe('Milestones', function() {
   describe('start', function() {
     // Run at the beginning of the request. Defaults to passthrough.
     it('should support chaining', function(done) {
-      var startCount;
+      var startCount = 0;
       test.userResource.read.start(function(req, res, context) {
-        startCount = 1;
+        startCount++;
         return context.continue();
       });
 


### PR DESCRIPTION
Currently if you defined a milestone for a before or after hook
it worked just fine since there was no existing function to call.
If, on the other hand, you wanted to add a milestone to a
pre-existing action, then your milestone would be called after the
existing function. This corrects that behavior.
