### PR TITLE
100% test coverage for epilogue

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -126,7 +126,7 @@ Controller.prototype._control = function(req, res) {
 
 Controller.prototype.milestone = function(name, callback) {
   if (!this[name])
-    throw new Error("couldn't find milestone: " + name);
+    throw new Error('invalid milestone: ' + name);
 
   if (!(this[name] instanceof Array))
     this[name] = [this[name]];

--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -16,10 +16,6 @@ Create.prototype.plurality = 'plural';
 
 Create.prototype.write = function(req, res, context) {
   context.attributes = _.extend(context.attributes, req.body);
-  this.endpoint.attributes.forEach(function(a) {
-    if (req.params.hasOwnProperty(a))
-      context.attributes[a] = req.params[a];
-  });
 
   var self = this;
   self.model

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -38,7 +38,7 @@ Delete.prototype.fetch = function(req, res, context) {
       res.status(500);
       context.error = {
         message: 'internal error',
-        errors: [err]
+        errors: [ err.message ]
       };
 
       return context.continue();

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -25,10 +25,6 @@ List.prototype.fetch = function(req, res, context) {
       count = +context.count || +req.query.count || defaultCount,
       offset = +context.offset || +req.query.offset || 0;
 
-  endpoint.attributes.forEach(function(attribute) {
-    criteria[attribute] = req.params[attribute];
-  });
-
   offset += context.page * count || req.query.page * count || 0;
   if (count > 1000) count = 1000;
   if (count < 0) count = defaultCount;
@@ -94,12 +90,6 @@ List.prototype.fetch = function(req, res, context) {
   model
     .findAndCountAll(options)
     .then(function(result) {
-      if (!result.rows) {
-        // TODO: support outside-of-range errors
-        res.json(404, { error: 'not found' });
-        return context.stop();
-      }
-
       context.instance = result.rows;
       var start = offset;
       var end = start + result.rows.length - 1;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -14,10 +14,6 @@ var Resource = function(options) {
 
   this.app = options.app;
   this.sequelize = options.sequelize;
-
-  if (!options.model)
-    throw new Error('resource needs a model');
-
   this.model = options.model;
   this.include = options.include;
   this.actions = options.actions;

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "request": "^2.53.0",
     "express": "^4.11.2",
     "body-parser": "^1.12.0",
-    "restify": "~2.8.3",
+    "restify": "^2.8.5",
     "mocha": "^2.1.0",
     "chai": "^2.0.0",
     "jshint": "^2.6.0",

--- a/tests/milestones/milestones.test.js
+++ b/tests/milestones/milestones.test.js
@@ -78,6 +78,16 @@ describe('Milestones', function() {
       });
     });
 
+    it('should throw an error on invalid milestone definition', function() {
+      try {
+        test.userResource.controllers.create.milestone('stert', function(req, res, context) {
+        // no-op
+        });
+      } catch (error) {
+        expect(error.message).to.equal('invalid milestone: stert');
+      }
+    });
+
   });
 
   describe('start', function() {


### PR DESCRIPTION
Added a few missing tests, and removed a number of questionable code
sections which were never run (or could never possibly be run). The
result is 100% test coverage for the the project.

Of note is:
 * the removal of endpoint attribute addition to context.attributes for the List and Create controllers (you would never do ```GET /users/:id``` for instance)
 * removal of a 404 status error when no results are found for list
    * this could actually never have been triggered, and I would argue that if you find nothing you should always return status 200 with a [] result set
 * otherwise code cleanup

