### PR TITLE
Add customization for sort parameter

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -58,16 +58,31 @@ List.prototype.fetch = function(req, res, context) {
       criteria = Sequelize.or.apply(null, search);
   }
 
-  if (req.query.sort) {
+  var sortParam = this.resource.sort.param;
+  if (_.has(req.query, sortParam)) {
     var order = [];
-    var sortColumns = req.query.sort.split(',');
+    var columnNames = [];
+    var sortColumns = req.query[sortParam].split(',');
     sortColumns.forEach(function(sortColumn) {
       if (sortColumn.indexOf('-') === 0) {
-        order.push([sortColumn.substring(1), 'DESC']);
+        var actualName = sortColumn.substring(1);
+        order.push([actualName, 'DESC']);
+        columnNames.push(actualName);
       } else {
+        columnNames.push(sortColumn);
         order.push([sortColumn, 'ASC']);
       }
     });
+    var allowedColumns = this.resource.sort.attributes || Object.keys(model.rawAttributes);
+    var disallowedColumns = _.difference(columnNames, allowedColumns);
+    if(disallowedColumns.length) {
+      res.status(400);
+      context.error = {
+        message: 'Sorting not allowed on given attributes',
+        errors: disallowedColumns
+      };
+      return context.continue();
+    }
 
     if (order.length)
       options.order = order;

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -9,6 +9,9 @@ var Resource = function(options) {
     pagination: true,
     search: {
       param: 'q'
+    },
+    sort: {
+      param: 'sort'
     }
   });
 
@@ -24,6 +27,7 @@ var Resource = function(options) {
   this.updateMethod = options.updateMethod;
   this.pagination = options.pagination;
   this.search = options.search;
+  this.sort = options.sort;
 
   this.controllers = {};
   this.actions.forEach(function(action) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -56,7 +56,8 @@ var epilogue = {
       include: args.include || [],
       pagination: args.pagination,
       updateMethod: this.updateMethod,
-      search: args.search
+      search: args.search,
+      sort: args.sort
     });
 
     return resource;

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -521,13 +521,6 @@ describe('Resource(basic)', function() {
       });
     });
 
-    it('should fail with invalid sort criteria', function(done) {
-      request.get({ url: test.baseUrl + '/users?sort=dogs' }, function(err, response, body) {
-        expect(response.statusCode).to.equal(500);
-        done();
-      });
-    });
-
     it('should set a default count if an invalid count was provided', function(done) {
       async.each([-1, 1001], function(count, callback) {
         request.get({

--- a/tests/resource/sort.test.js
+++ b/tests/resource/sort.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+var request = require('request'),
+    expect = require('chai').expect,
+    _ = require('lodash'),
+    rest = require('../../lib'),
+    test = require('../support');
+
+describe('Resource(sort)', function() {
+  before(function() {
+    test.models.User = test.db.define('users', {
+      id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },
+      username: {
+        type: test.Sequelize.STRING,
+        allowNull: false
+      },
+      email: {
+        type: test.Sequelize.STRING,
+        unique: { msg: 'must be unique' },
+        validate: { isEmail: true }
+      }
+    }, {
+      underscored: true,
+      timestamps: false
+    });
+
+    test.userlist = [
+      { username: 'arthur', email: 'arthur@gmail.com' },
+      { username: 'james', email: 'james@gmail.com' },
+      { username: 'henry', email: 'henry@gmail.com' },
+      { username: 'william', email: 'william@gmail.com' },
+      { username: 'edward', email: 'edward@gmail.com' },
+      { username: 'arthur', email: 'aaaaarthur@gmail.com' }
+    ];
+  });
+
+  beforeEach(function(done) {
+    test.initializeDatabase(function() {
+      test.initializeServer(function() {
+        rest.initialize({
+          app: test.app,
+          sequelize: test.Sequelize
+        });
+
+        return test.models.User.bulkCreate(test.userlist).then(function() {
+          done();
+        });
+      });
+    });
+  });
+
+  afterEach(function(done) {
+    test.clearDatabase(function() {
+      test.server.close(done);
+    });
+  });
+
+  it('should sort with default options', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id']
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?sort=username'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+        var records = JSON.parse(body).map(function(r) {
+          return _.omit(r, 'id');
+        });
+        expect(records).to.eql(_.sortByAll(test.userlist, ['username']));
+        done();
+    });
+  });
+
+  it('should sort with custom param', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        param: 'orderby'
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?orderby=email'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) {
+        return _.omit(r, 'id');
+      });
+      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      done();
+    });
+  });
+
+  it('should sort with restricted attributes', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        attributes: ['email']
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?sort=email'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) {
+        return _.omit(r, 'id');
+      });
+      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      done();
+    });
+  });
+
+  it('should fail sorting with a restricted attribute', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        attributes: ['email']
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?sort=username'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(400);
+      var result = JSON.parse(body);
+      expect(result.message).to.contain('Sorting not allowed');
+      expect(result.errors).to.eql(['username']);
+      done();
+    });
+  });
+
+  it('should fail sorting with multiple restricted attributes', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        attributes: ['email']
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?sort=username,-invalid'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(400);
+      var result = JSON.parse(body);
+      expect(result.message).to.contain('Sorting not allowed');
+      expect(result.errors).to.eql(['username','invalid']);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Adds customization of the sort parameter in a listing

```javascript
rest.resource({
  model: test.models.User,
  endpoints: ['/users', '/users/:id'],
  sort: {
    param: 'orderby',
    attributes: ['username', 'createdAt']
  }
});
```

param - choose the query parameter that is read for the sort, defaults to the existing 'sort'
attributes - list of fields that are allowed to be sorted on, defaults to all the raw attributes of the model

If a sorting attribute isn't included in the list of attributes (or in the raw attributes if the array isn't supplied) it will return a 400 bad request with an error message saying that sorting by the attribute is not allowed. This is a change from the current behaviour of waiting for the query to fail (for invalid columns) and returning an 500 internal server error.