### PR TITLE
Use promises in hook system and change how errors are created

### DIFF
--- a/docs/Milestones.md
+++ b/docs/Milestones.md
@@ -1,0 +1,189 @@
+# Milestones
+
+Milestones provide opportunities to run custom application code at various important steps throughout the duration of the request.
+
+Resources have properties for each controller action: `create`, `list`, `read`, `update`, and `delete`.
+Also find a meta property `all` as a convenience for hooking into milestones across all controllers.
+Each of those properties in turn has methods for setting custom behavior.
+
+For each milestone on a given controller we accept a function to specify custom behavior. If multiple functions are
+registered for a hook they will be ran in order.
+
+Functions can expect three parameters: a request, a response, and a context object.
+
+For example to run before the main fetch milestone:
+
+```javascript
+// check the cache first
+users.list.fetch.before(function(req, res, context) {
+	var instance = cache.get(context.criteria);
+
+	if (instance) {
+		// keep a reference to the instance and skip the fetch
+		context.instance = instance;
+		return context.skip;
+	} else {
+		// cache miss; we continue on
+		return context.continue;
+	}
+})
+```
+
+We have the following milestones:
+
+- start - ran at the beginning of the request
+- auth - authorize the request
+- fetch - fetch data from the database
+- data - transform the database data
+- write - write to the database
+- send - send response to the user
+- complete - request completed
+
+Only send is defined for all actions, and defaults to returning the json format of context.instance to the browser.
+
+# Default Milestones for actions
+
+## create
+
+### write
+
+Reads from context.attributes and req.body and creates a new instance of the model. Causes the response to have a
+HTTP 201 response and sets the instance on context.instance
+
+## delete
+
+### fetch
+
+Fetches from the database based on the endpoint parameters.
+Sets context.instance to the data if it is found, otherwise throws a 404 error.
+
+### write
+
+Deletes the instance from the database and clears context.instance
+
+## list
+
+### fetch
+
+Fetches a list from the database based on the URL parameters and endpoint configuration. Sets context.instance to the
+returned list.
+
+## read
+
+### fetch
+
+Fetches data from the database based on the request parameters and endpoint configuration and sets context.instance to
+the returned object or throws a 404 error if none found that match
+
+# Milestone Flow
+
+Inside the function you must do one of the following:
+
+1. return either `context.stop`, `context.skip` or `context.continue`
+2. return a promise/thenable that resolves to `context.stop`, `context.skip` or `context.continue`
+3. call either `context.stop()`, `context.skip()` or `context.continue()`
+4. throw an error
+5. call `context.error(err)` with an error to show
+
+Examples:
+
+```javascript
+// example for 1
+users.list.fetch.before(function(req, res, context) {
+	return context.continue;
+});
+
+// example for 2 and 4
+users.list.fetch.before(function(req, res, context) {
+	return checkLoggedIn(function(loggedIn) {
+		if(!loggedIn) {
+			throw new ForbiddenError();
+		}
+		return context.continue;
+	});
+});
+
+// example for 3 and 5
+users.list.fetch.before(function(req, res, context) {
+	passport.authenticate('bearer', function(err, user, info) {
+		if(err) {
+			res.status(500);
+			return context.stop();
+		}
+
+		if(user) {
+			context.continue();
+		} else {
+			context.error(new ForbiddenError());
+		}
+	});
+});
+
+```
+
+## context.continue
+
+This says to contiue on to the next hook in the chain.
+
+## context.skip
+
+This skips all the remaining functions on a milestone and skips to the start of the next one
+
+## context.stop
+
+This stops execution of all the remaining hooks and milestones and finishes the request. If you use context.stop you
+should also set the response `res.status(200).json({})`
+
+## context.error(error)
+
+This should be called when throwing an error won't work. If you are returning a promise or working sync then throwing
+an error will be better
+
+# Errors
+
+Throwing an error within a milestone function will cause the milestones to stop execution and the error message will be displayed to the user in the format:
+
+```json
+{
+    "message": "Error message",
+    "errors": []
+}
+```
+
+To make use of this you must use an error that extends EpilogueError. Any error thrown that is not an instance of
+EpilogueError will be shown as an Internal Server Error with it's errors array set to the error message.
+
+In situations where throwing an error is not possible you can use `context.error(err)` with the error object or
+alternatively call `context.error(status, message, [errors])` for it to build an EpilogueError for you with the supplied
+parameters
+
+The following errors are provided on epilogue.Errors:
+
+## EpilogueError(statusCode, message, errors)
+
+This is the parent class you can extend to make your own errors
+
+`statusCode` = the HTTP status code to return, defaults to 500
+`message` = the error message to show in the message field, defaults to 'EpilogueError'
+`errors` = an array of error strings to show in the message, defaults to []
+
+## BadRequestError(message, errors)
+
+This returns a HTTP 400 response
+
+`message` = the error message to show in the message field, defaults to 'Bad Request'
+`errors` = an array of error strings to show in the message, defaults to []
+
+## ForbiddenError(message, errors)
+
+This returns a HTTP 403 response
+
+`message` = the error message to show in the message field, defaults to 'Forbidden'
+`errors` = an array of error strings to show in the message, defaults to []
+
+## NotFoundError(message, errors)
+
+This returns a HTTP 404 response
+
+`message` = the error message to show in the message field, defaults to 'Not Found'
+`errors` = an array of error strings to show in the message, defaults to []

--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -1,8 +1,9 @@
 'use strict';
 
-var async = require('async'),
-    _ = require('lodash'),
-    Endpoint = require('../Endpoint');
+var _ = require('lodash'),
+    Endpoint = require('../Endpoint'),
+    Promise = require('bluebird'),
+    errors = require('../Errors');
 
 var Controller = function(args) {
   this.initialize(args);
@@ -55,18 +56,17 @@ Controller.hooks = Controller.milestones.reduce(function(hooks, milestone) {
   return hooks;
 }, []);
 
-Controller.prototype.error = function(req, res) {
-  // passthrough
+Controller.prototype.error = function(req, res, err) {
+  res.status(err.status);
+  res.json({
+    message: err.message,
+    errors: err.errors
+  });
 };
 
 Controller.prototype.send = function(req, res, context) {
-  if (context.error !== undefined) {
-    res.json(context.error);
-    return context.continue();
-  }
-
   res.json(context.instance);
-  return context.continue();
+  return context.continue;
 };
 
 Controller.prototype.route = function() {
@@ -84,18 +84,12 @@ Controller.prototype.route = function() {
 };
 
 Controller.prototype._control = function(req, res) {
-  var work = [],
-      _callback,
-      skip = false,
+  var hookChain = Promise.resolve(false),
       self = this,
       context = {
         instance: undefined,
         criteria: {},
-        attributes: {},
-        error: undefined,
-        continue: function() { _callback(); },
-        stop: function() { _callback(true); },
-        skip: function() { skip = true; _callback(); }
+        attributes: {}
       };
 
   Controller.milestones.forEach(function(milestone) {
@@ -106,30 +100,88 @@ Controller.prototype._control = function(req, res) {
       if (!self[hook])
         return;
 
-      var functions = Array.isArray(self[hook]) ? self[hook] : [ self[hook] ];
-      functions.forEach(function(f) {
-        work.push(function(callback) {
-          if (skip) return callback();
-          _callback = callback;
+      hookChain = hookChain.then(function runHook(skip) {
+        if (skip) return true;
 
-          f.call(self, req, res, context);
-        });
+        var functions = Array.isArray(self[hook]) ? self[hook] : [self[hook]];
+
+        // return the function chain. This means if the function chain resolved
+        // to skip then all the remaining hooks on this milestone will also be
+        // skipped and we will go to the next milestone
+        return functions.reduce(function(prev, current) {
+          return prev.then(function runHookFunction(skipNext) {
+
+            // if any asked to skip keep returning true to avoid calling further
+            // functions inside this hook
+            if (skipNext) return true;
+
+            var decisionPromise = new Promise(function(resolve) {
+              _.assign(context, {
+                skip: function() {
+                  resolve(context.skip);
+                },
+                stop: function() {
+                  resolve(new errors.RequestCompleted());
+                },
+                continue: function() {
+                  resolve(context.continue);
+                },
+                error: function(status, message, errorList, cause) {
+                  // if the second parameter is undefined then we are being
+                  // passed an error to rethrow, otherwise build an EpilogueError
+                  if (_.isUndefined(message)) {
+                    resolve(status);
+                  } else {
+                    resolve(new errors.EpilogueError(status, message, errorList, cause));
+                  }
+                }
+              });
+            });
+
+            return Promise.resolve(current.call(self, req, res, context))
+              .then(function(result) {
+                // if they were returned directly or as a result of a promise
+                if (_.includes([context.skip, context.continue, context.stop], result)) {
+                  // call it to resolve the decision
+                  result();
+                }
+
+                return decisionPromise.then(function(decision) {
+                  if (decision === context.continue) return false;
+                  if (decision === context.skip) return true;
+
+                  // must be an error/context.stop, throw the decision for error handling
+                  throw decision;
+                });
+              });
+          });
+        }, Promise.resolve(false));
       });
     });
 
-    // reset skip before each milestone
-    work.push(function(callback) {
-      skip = false;
-      callback();
+    hookChain = hookChain.then(function() {
+      // clear any passed results so the next milestone will run even if a
+      // _after said to skip
+      return false;
     });
   });
 
-  async.series(
-    work,
-    function(err, results) {
-      if (err) self.error(req, res);
-    }
-  );
+  hookChain
+    .catch(errors.RequestCompleted, _.noop)
+    .catch(self.model.sequelize.ValidationError, function(err) {
+      var errorList = _.reduce(err.errors, function(result, error) {
+        result.push({ field: error.path, message: error.message });
+        return result;
+      }, []);
+
+      self.error(req, res, new errors.BadRequestError(err.message, errorList, err));
+    })
+    .catch(errors.EpilogueError, function(err) {
+      self.error(req, res, err);
+    })
+    .catch(function(err) {
+      self.error(req, res, new errors.EpilogueError(500, 'internal error', [err.message], err));
+    });
 };
 
 Controller.prototype.milestone = function(name, callback) {

--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -18,7 +18,7 @@ Create.prototype.write = function(req, res, context) {
   context.attributes = _.extend(context.attributes, req.body);
 
   var self = this;
-  self.model
+  return self.model
     .create(context.attributes)
     .then(function(instance) {
       if (self.resource) {
@@ -32,28 +32,7 @@ Create.prototype.write = function(req, res, context) {
 
       res.status(201);
       context.instance = instance;
-      context.continue();
-    })
-    .catch(self.model.sequelize.ValidationError, function(err) {
-      res.status(400);
-      context.error = {
-        message: err.message,
-        errors: _.reduce(err.errors, function(result, error) {
-          result.push({ field: error.path, message: error.message });
-          return result;
-        }, [])
-      };
-
-      return context.skip();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [ err.message ]
-      };
-
-      return context.skip();
+      return context.continue;
     });
 };
 

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var util = require('util'),
-    Base = require('./base');
+    Base = require('./base'),
+    errors = require('../Errors');
 
 var Delete = function(args) {
   Delete.super_.call(this, args);
@@ -22,48 +23,24 @@ Delete.prototype.fetch = function(req, res, context) {
     criteria[attribute] = req.params[attribute];
   });
 
-  model
+  return model
     .find({ where: criteria })
     .then(function(instance) {
       if (!instance) {
-        res.status(404);
-        context.error = { message: 'not found' };
-        return context.continue();
+        throw new errors.NotFoundError();
       }
 
       context.instance = instance;
-      return context.continue();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [ err.message ]
-      };
-
-      return context.continue();
+      return context.continue;
     });
 };
 
 Delete.prototype.write = function(req, res, context) {
-  if (context.error !== undefined) {
-    return context.skip();
-  }
-
-  context.instance
+  return context.instance
     .destroy()
     .then(function() {
       context.instance = {};
-      return context.continue();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [ err.message ]
-      };
-
-      return context.continue();
+      return context.continue;
     });
 };
 

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -2,7 +2,8 @@
 
 var util = require('util'),
     Base = require('./base'),
-    _ = require('lodash');
+    _ = require('lodash'),
+    errors = require('../Errors');
 
 var List = function(args) {
   List.super_.call(this, args);
@@ -75,13 +76,8 @@ List.prototype.fetch = function(req, res, context) {
     });
     var allowedColumns = this.resource.sort.attributes || Object.keys(model.rawAttributes);
     var disallowedColumns = _.difference(columnNames, allowedColumns);
-    if(disallowedColumns.length) {
-      res.status(400);
-      context.error = {
-        message: 'Sorting not allowed on given attributes',
-        errors: disallowedColumns
-      };
-      return context.continue();
+    if (disallowedColumns.length) {
+      throw new errors.BadRequestError('Sorting not allowed on given attributes', disallowedColumns);
     }
 
     if (order.length)
@@ -102,7 +98,7 @@ List.prototype.fetch = function(req, res, context) {
     options.where = criteria;
 
   var self = this;
-  model
+  return model
     .findAndCountAll(options)
     .then(function(result) {
       context.instance = result.rows;
@@ -112,13 +108,8 @@ List.prototype.fetch = function(req, res, context) {
 
       if (!!self.resource.pagination)
         res.header('Content-Range', 'items ' + [[start, end].join('-'), result.count].join('/'));
-      return context.continue();
 
-    })
-    .catch(function(err) {
-      res.status(500);
-      res.json({ error: err });
-      return context.stop();
+      return context.continue;
     });
 };
 

--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var util = require('util'),
-    Base = require('./base');
+    Base = require('./base'),
+    errors = require('../Errors');
 
 var Read = function(args) {
   Read.super_.call(this, args);
@@ -37,26 +38,15 @@ Read.prototype.fetch = function(req, res, context) {
       });
   }
 
-  model
+  return model
     .find(options)
     .then(function(instance) {
       if (!instance) {
-        res.status(404);
-        context.error = { message: 'not found' };
-        return context.continue();
+        throw new errors.NotFoundError();
       }
 
       context.instance = instance;
-      return context.continue();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [ err.message ]
-      };
-
-      return context.continue();
+      return context.continue;
     });
 };
 

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -2,7 +2,8 @@
 
 var _ = require('lodash'),
     util = require('util'),
-    Base = require('./base');
+    Base = require('./base'),
+    errors = require('../Errors');
 
 var Update = function(args) {
   if (args.resource.updateMethod)
@@ -25,32 +26,19 @@ Update.prototype.fetch = function(req, res, context) {
     criteria[attribute] = req.params[attribute];
   });
 
-  model
+  return model
     .find({ where: criteria })
     .then(function(instance) {
       if (!instance) {
-        res.status(404);
-        context.error = { error: 'not found' };
-        return context.continue();
+        throw new errors.NotFoundError();
       }
 
       context.instance = instance;
-      context.continue();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [err]
-      };
-
-      return context.continue();
+      return context.continue;
     });
 };
 
 Update.prototype.write = function(req, res, context) {
-  if (!!context.error) context.skip();
-
   var instance = context.instance;
   context.attributes = _.extend(context.attributes, req.body);
 
@@ -60,32 +48,11 @@ Update.prototype.write = function(req, res, context) {
   });
 
   instance.setAttributes(context.attributes);
-  instance
+  return instance
     .save()
     .then(function(instance) {
       context.instance = instance;
-      context.continue();
-    })
-    .catch(instance.sequelize.ValidationError, function(err) {
-      res.status(400);
-      context.error = {
-        message: err.message,
-        errors: _.reduce(err.errors, function(result, error) {
-          result.push({ field: error.path, message: error.message });
-          return result;
-        }, [])
-      };
-
-      return context.skip();
-    })
-    .catch(function(err) {
-      res.status(500);
-      context.error = {
-        message: 'internal error',
-        errors: [ err.message ]
-      };
-
-      return context.skip();
+      return context.continue;
     });
 };
 

--- a/lib/Errors.js
+++ b/lib/Errors.js
@@ -1,0 +1,45 @@
+'use strict';
+
+var util = require('util');
+
+var EpilogueError = function(status, message, errors, cause) {
+  this.name = 'EpilogueError';
+  this.message = message || 'EpilogueError';
+  this.errors = errors || [];
+  this.status = status || 500;
+  this.cause = cause;
+  Error.captureStackTrace(this, this.constructor);
+};
+util.inherits(EpilogueError, Error);
+
+var BadRequestError = function(message, errors, cause) {
+  EpilogueError.call(this, 400, message || 'Bad Request', errors, cause);
+  this.name = 'BadRequestError';
+};
+util.inherits(BadRequestError, EpilogueError);
+
+var ForbiddenError = function(message, errors, cause) {
+  EpilogueError.call(this, 403, message || 'Forbidden', errors, cause);
+  this.name = 'ForbiddenError';
+};
+util.inherits(ForbiddenError, EpilogueError);
+
+var NotFoundError = function(message, errors, cause) {
+  EpilogueError.call(this, 404, message || 'Not Found', errors, cause);
+  this.name = 'NotFoundError';
+};
+util.inherits(NotFoundError, EpilogueError);
+
+var RequestCompleted = function() {
+  Error.call(this);
+  this.name = 'RequestCompleted';
+};
+util.inherits(RequestCompleted, Error);
+
+module.exports = {
+    NotFoundError: NotFoundError,
+    BadRequestError: BadRequestError,
+    EpilogueError: EpilogueError,
+    ForbiddenError: ForbiddenError,
+    RequestCompleted: RequestCompleted
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,6 +3,7 @@
 var Resource = require('./Resource'),
     Endpoint = require('./Endpoint'),
     Controllers = require('./Controllers'),
+    Errors = require('./Errors'),
     inflection = require('inflection'),
     _ = require('lodash');
 
@@ -65,7 +66,8 @@ var epilogue = {
 
   Resource: Resource,
   Endpoint: Endpoint,
-  Controllers: Controllers
+  Controllers: Controllers,
+  Errors: Errors
 };
 
 module.exports = epilogue;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "epilogue",
   "description": "Create REST resources and controllers with Sequelize and Express or Restify",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": "David Chester <dchester@shutterstock.com>",
   "contributors": [
     {

--- a/tests/milestones/data/test-middleware-before-after.js
+++ b/tests/milestones/data/test-middleware-before-after.js
@@ -23,15 +23,15 @@ actions.forEach(function(action) {
     TestMiddlewareBeforeAfter[action][milestone] = {
       before: function(req, res, context) {
         TestMiddlewareBeforeAfter.results[action][milestone].before = true;
-        context.continue();
+        return context.continue;
       },
       action: function(req, res, context) {
         TestMiddlewareBeforeAfter.results[action][milestone].action = true;
-        context.continue();
+        return context.continue;
       },
       after: function(req, res, context) {
         TestMiddlewareBeforeAfter.results[action][milestone].after = true;
-        context.continue();
+        return context.continue;
       }
     };
   });

--- a/tests/milestones/data/test-middleware.js
+++ b/tests/milestones/data/test-middleware.js
@@ -18,7 +18,7 @@ actions.forEach(function(action) {
     TestMiddleware.results[action][milestone] = false;
     TestMiddleware[action][milestone] = function(req, res, context) {
       TestMiddleware.results[action][milestone] = true;
-      context.continue();
+      return context.continue;
     };
   });
 });

--- a/tests/milestones/middleware.test.js
+++ b/tests/milestones/middleware.test.js
@@ -14,7 +14,7 @@ function verifyBeforeAndAfter(object) {
   expect(object.after).to.be.true;
 }
 
-describe('Milestones(middleware)', function() {
+describe('Middleware', function() {
   before(function() {
     test.models.User = test.db.define('users', {
       id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true },

--- a/tests/milestones/milestones.test.js
+++ b/tests/milestones/milestones.test.js
@@ -4,7 +4,11 @@ var request = require('request'),
     expect = require('chai').expect,
     _ = require('lodash'),
     rest = require('../../lib'),
-    test = require('../support');
+    test = require('../support'),
+    errors = require('../../lib/Errors'),
+    RequestCompleted = errors.RequestCompleted,
+    EpilogueError = errors.EpilogueError,
+    Promise = require('bluebird');
 
 describe('Milestones', function() {
   before(function() {
@@ -46,22 +50,381 @@ describe('Milestones', function() {
   });
 
   // TESTS
-  describe('general behavior', function() {
-    it('should skip the main action if context.skip is called in before hook', function(done) {
-      var SkipMiddleware = {
+  describe('context.continue', function() {
+    var ContinueMiddleware;
+
+    beforeEach(function() {
+      ContinueMiddleware = {
         results: {
           beforeCalled: false,
           actionCalled: false
         },
         create: {
           write: {
-            before: function(req, res, context) {
-              SkipMiddleware.results.beforeCalled = true;
-              context.skip();
-            },
+            action: function(req, res, context) {
+              ContinueMiddleware.results.actionCalled = true;
+              context.continue();
+            }
+          }
+        }
+      };
+    });
+
+    function checkContinued(done) {
+      request.post({
+        url: test.baseUrl + '/users',
+        json: { username: 'jamez', email: 'jamez@gmail.com' }
+      }, function(err, response, body) {
+        expect(ContinueMiddleware.results.beforeCalled).to.be.true;
+        expect(ContinueMiddleware.results.actionCalled).to.be.true;
+        done();
+      });
+    }
+
+    it('should support running as a function', function(done) {
+      ContinueMiddleware.create.write.before = function(req, res, context) {
+        ContinueMiddleware.results.beforeCalled = true;
+        context.continue();
+      };
+
+      test.userResource.use(ContinueMiddleware);
+      checkContinued(done);
+    });
+
+    it('should support a return value', function(done) {
+      ContinueMiddleware.create.write.before = function(req, res, context) {
+        ContinueMiddleware.results.beforeCalled = true;
+        return context.continue;
+      };
+
+      test.userResource.use(ContinueMiddleware);
+      checkContinued(done);
+    });
+
+    it('should support returning a promise', function(done) {
+      ContinueMiddleware.create.write.before = function(req, res, context) {
+        ContinueMiddleware.results.beforeCalled = true;
+        return new Promise(function(resolve) {
+          resolve(context.continue);
+        });
+      };
+
+      test.userResource.use(ContinueMiddleware);
+      checkContinued(done);
+    });
+  });
+
+  describe('context.stop', function() {
+    var StopMiddleware;
+
+    beforeEach(function() {
+      StopMiddleware = {
+        results: {
+          beforeCalled: false,
+          actionCalled: false
+        },
+        create: {
+          write: {
+            action: function(req, res, context) {
+              StopMiddleware.results.actionCalled = true;
+              context.continue();
+            }
+          }
+        }
+      };
+    });
+
+    function checkStopped(done) {
+      request.post({
+        url: test.baseUrl + '/users',
+        json: { username: 'jamez', email: 'jamez@gmail.com' }
+      }, function(err, response, body) {
+        expect(StopMiddleware.results.beforeCalled).to.be.true;
+        expect(StopMiddleware.results.actionCalled).to.be.false;
+        expect(response.statusCode).to.be.eql(420);
+        done();
+      });
+    }
+
+    function setResponse(res) {
+      res.status(420);
+      res.json({test: 'test'});
+    }
+
+    it('should support running as a function', function(done) {
+      StopMiddleware.create.write.before = function(req, res, context) {
+        StopMiddleware.results.beforeCalled = true;
+        setResponse(res);
+        context.stop();
+      };
+
+      test.userResource.use(StopMiddleware);
+      checkStopped(done);
+    });
+
+    it('should support a return value', function(done) {
+      StopMiddleware.create.write.before = function(req, res, context) {
+        StopMiddleware.results.beforeCalled = true;
+        setResponse(res);
+        return context.stop;
+      };
+
+      test.userResource.use(StopMiddleware);
+      checkStopped(done);
+    });
+
+    it('should support returning a promise', function(done) {
+      StopMiddleware.create.write.before = function(req, res, context) {
+        StopMiddleware.results.beforeCalled = true;
+        return new Promise(function(resolve) {
+          setResponse(res);
+          resolve(context.stop);
+        });
+      };
+
+      test.userResource.use(StopMiddleware);
+      checkStopped(done);
+    });
+
+    it('should support thowing RequestCompleted error', function(done) {
+      StopMiddleware.create.write.before = function(req, res, context) {
+        StopMiddleware.results.beforeCalled = true;
+        setResponse(res);
+        throw new RequestCompleted();
+      };
+
+      test.userResource.use(StopMiddleware);
+      checkStopped(done);
+    });
+  });
+
+  describe('context.skip', function() {
+    var SkipMiddleware;
+
+    beforeEach(function() {
+      SkipMiddleware = {
+        results: {
+          beforeCalled: false,
+          actionCalled: false,
+          sendCalled: false
+        },
+        create: {
+          write: {
             action: function(req, res, context) {
               SkipMiddleware.results.actionCalled = true;
               context.continue();
+            }
+          },
+          send: {
+            action: function(req, res, context) {
+              SkipMiddleware.results.sendCalled = true;
+              context.continue();
+            }
+          }
+        }
+      };
+    });
+
+    function checkSkipped(done) {
+      request.post({
+        url: test.baseUrl + '/users',
+        json: { username: 'jamez', email: 'jamez@gmail.com' }
+      }, function(err, response, body) {
+        expect(SkipMiddleware.results.beforeCalled).to.be.true;
+        expect(SkipMiddleware.results.actionCalled).to.be.false;
+        expect(SkipMiddleware.results.sendCalled).to.be.true;
+        done();
+      });
+    }
+
+    it('should support running as a function', function(done) {
+      SkipMiddleware.create.write.before = function(req, res, context) {
+        SkipMiddleware.results.beforeCalled = true;
+        context.skip();
+      };
+
+      test.userResource.use(SkipMiddleware);
+      checkSkipped(done);
+    });
+
+    it('should support a return value', function(done) {
+      SkipMiddleware.create.write.before = function(req, res, context) {
+        SkipMiddleware.results.beforeCalled = true;
+        return context.skip;
+      };
+
+      test.userResource.use(SkipMiddleware);
+      checkSkipped(done);
+    });
+
+    it('should support returning a promise', function(done) {
+      SkipMiddleware.create.write.before = function(req, res, context) {
+        SkipMiddleware.results.beforeCalled = true;
+        return new Promise(function(resolve) {
+          resolve(context.skip);
+        });
+      };
+
+      test.userResource.use(SkipMiddleware);
+      checkSkipped(done);
+    });
+  });
+
+  describe('throwing errors', function() {
+    var ErrorMiddleware, error;
+
+    beforeEach(function () {
+      ErrorMiddleware = {
+        results: {
+          beforeCalled: false,
+          actionCalled: false
+        },
+        create: {
+          write: {
+            action: function (req, res, context) {
+              ErrorMiddleware.results.actionCalled = true;
+              context.continue();
+            }
+          }
+        }
+      };
+      error = new EpilogueError(420, 'test error', ['test', 'error']);
+    });
+
+    function checkErrored(done) {
+      request.post({
+        url: test.baseUrl + '/users',
+        json: {username: 'jamez', email: 'jamez@gmail.com'}
+      }, function (err, response, body) {
+        expect(ErrorMiddleware.results.beforeCalled).to.be.true;
+        expect(ErrorMiddleware.results.actionCalled).to.be.false;
+        expect(response.statusCode).to.be.eql(error.status);
+        expect(body.message).to.be.eql(error.message);
+        expect(body.errors).to.be.eql(error.errors);
+        done();
+      });
+    }
+
+    it('should support throw in sync', function (done) {
+      ErrorMiddleware.create.write.before = function (req, res, context) {
+        ErrorMiddleware.results.beforeCalled = true;
+        throw error;
+      };
+
+      test.userResource.use(ErrorMiddleware);
+      checkErrored(done);
+    });
+
+    it('should support throwing in a promise', function (done) {
+      ErrorMiddleware.create.write.before = function (req, res, context) {
+        ErrorMiddleware.results.beforeCalled = true;
+        return new Promise(function (resolve) {
+          throw error;
+        });
+      };
+
+      test.userResource.use(ErrorMiddleware);
+      checkErrored(done);
+    });
+
+    it('should support context.error function when in a callback', function (done) {
+      ErrorMiddleware.create.write.before = function (req, res, context) {
+        ErrorMiddleware.results.beforeCalled = true;
+
+        setTimeout(function() {
+          context.error(error);
+        }, 200);
+      };
+
+      test.userResource.use(ErrorMiddleware);
+      checkErrored(done);
+    });
+
+    it('should support context.error function with error constructor arguments', function (done) {
+      ErrorMiddleware.create.write.before = function (req, res, context) {
+        ErrorMiddleware.results.beforeCalled = true;
+
+        context.error(420, 'test error', ['test', 'error']);
+      };
+
+      test.userResource.use(ErrorMiddleware);
+      checkErrored(done);
+    });
+  });
+
+  describe('Errors', function() {
+    it('should allow error messages to be changed before send', function(done) {
+      var expectedBody = 'Expected Body';
+      test.userResource.controllers.create.error = function(req, res, err) {
+        res.status(400);
+        res.send(expectedBody);
+      };
+
+      request.post({
+        url: test.baseUrl + '/users',
+        json: { username: 'jamez', email: 'totally gonna fail email validation' }
+      }, function(err, response, body) {
+        expect(body).to.equal(expectedBody);
+        expect(response.statusCode).to.equal(400);
+        done();
+      });
+    });
+  });
+
+  describe('general behavior', function() {
+    it('should not skip the before action of next milestone if an after resolved to skip', function(done) {
+      var SkipMiddleware = {
+        results: {
+          beforeCalled: false,
+          afterCalled: false
+        },
+        create: {
+          write: {
+            after: function(req, res, context) {
+              SkipMiddleware.results.afterCalled = true;
+              return context.skip;
+            }
+          },
+          send: {
+            before: function(req, res, context) {
+              SkipMiddleware.results.beforeCalled = true;
+              return context.continue;
+            }
+          }
+        }
+      };
+
+      test.userResource.use(SkipMiddleware);
+      request.post({
+        url: test.baseUrl + '/users',
+        json: { username: 'jamez', email: 'jamez@gmail.com' }
+      }, function(err, response, body) {
+        expect(SkipMiddleware.results.afterCalled).to.be.true;
+        expect(SkipMiddleware.results.beforeCalled).to.be.true;
+        done();
+      });
+    });
+
+    it('should skip the action and after hooks if skip is returned in before hook', function(done) {
+      var SkipMiddleware = {
+        results: {
+          beforeCalled: false,
+          actionCalled: false,
+          afterCalled: false
+        },
+        create: {
+          write: {
+            before: function(req, res, context) {
+              SkipMiddleware.results.beforeCalled = true;
+              return context.skip;
+            },
+            action: function(req, res, context) {
+              SkipMiddleware.results.actionCalled = true;
+              return context.continue;
+            },
+            after: function(req, res, context) {
+              SkipMiddleware.results.afterCalled = true;
+              return context.continue;
             }
           }
         }
@@ -74,6 +437,7 @@ describe('Milestones', function() {
       }, function(err, response, body) {
         expect(SkipMiddleware.results.beforeCalled).to.be.true;
         expect(SkipMiddleware.results.actionCalled).to.be.false;
+        expect(SkipMiddleware.results.afterCalled).to.be.false;
         done();
       });
     });
@@ -96,12 +460,12 @@ describe('Milestones', function() {
       var startCount;
       test.userResource.read.start(function(req, res, context) {
         startCount = 1;
-        return context.continue();
+        return context.continue;
       });
 
       test.userResource.read.start(function(req, res, context) {
         startCount++;
-        return context.continue();
+        return context.continue;
       });
 
       request.get({ url: test.baseUrl + '/users/1' }, function(err, response, body) {
@@ -123,7 +487,7 @@ describe('Milestones', function() {
       var mockData = { username: 'mocked', email: 'mocked@gmail.com' };
       test.userResource.read.fetch.before(function(req, res, context) {
         context.instance = mockData;
-        return context.skip();
+        return context.skip;
       });
 
       request.post({
@@ -148,7 +512,7 @@ describe('Milestones', function() {
       var expected = { username: 'jamez', email: 'injected@email.com' };
       test.userResource.read.fetch.after(function(req, res, context) {
         context.instance.email = 'injected@email.com';
-        return context.skip();
+        return context.skip;
       });
 
       request.post({
@@ -180,76 +544,6 @@ describe('Milestones', function() {
 
   describe('send', function() {
     // Send the HTTP response, headers along with the data in context.instance.
-
-    it('should support modifying error data on create before sending response', function(done) {
-      var expected = { error: 'Injected error message' };
-      test.userResource.create.send.before(function(req, res, context) {
-        if (context.error !== undefined) {
-          context.error = expected;
-        }
-        context.continue();
-      });
-
-      request.post({
-        url: test.baseUrl + '/users',
-        json: { username: 'jamez', email: 'not an email address' }
-      }, function(err, response, body) {
-        expect(err).to.be.null;
-        expect(response.statusCode).to.equal(400);
-        var result = _.isObject(body) ? body : JSON.parse(body);
-        expect(result).to.eql(expected);
-        done();
-      });
-    });
-
-    it('should support modifying error data on update before sending response', function(done) {
-      var expected = { error: 'Injected error message' };
-      test.userResource.update.send.before(function(req, res, context) {
-        if (context.error !== undefined) {
-          context.error = expected;
-        }
-        context.continue();
-      });
-
-      request.post({
-        url: test.baseUrl + '/users',
-        json: { username: 'jamez', email: 'jamez@gmail.com' }
-      }, function(err, response, body) {
-        expect(err).to.be.null;
-        expect(response.statusCode).to.equal(201);
-
-        var path = response.headers.location;
-        request.put({
-          url: test.baseUrl + path,
-          json: { email: 'not an email address' }
-        }, function(err, response, body) {
-          expect(err).to.be.null;
-          expect(response.statusCode).to.equal(400);
-          var result = _.isObject(body) ? body : JSON.parse(body);
-          expect(result).to.eql(expected);
-          done();
-        });
-      });
-    });
-
-    it('should support modifying error data on delete before sending response', function(done) {
-      var expected = { error: 'Injected error message' };
-      test.userResource.delete.send.before(function(req, res, context) {
-        if (context.error !== undefined) {
-          context.error = expected;
-        }
-        context.continue();
-      });
-
-      request.del({
-        url: test.baseUrl + '/users/-1'
-      }, function(err, response, body) {
-        var result = _.isObject(body) ? body : JSON.parse(body);
-        expect(response.statusCode).to.equal(404);
-        expect(result).to.eql(expected);
-        done();
-      });
-    });
   });
 
   describe('complete', function() {

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -62,7 +62,7 @@ describe('Resource(basic)', function() {
             test.userResource.enableCriteriaTest = false;
           }
 
-          context.continue();
+          return context.continue;
         });
 
         done();
@@ -241,7 +241,8 @@ describe('Resource(basic)', function() {
       }, function(err, response, body) {
         expect(response.statusCode).to.equal(404);
         var record = _.isObject(body) ? body : JSON.parse(body);
-        expect(record).to.contain.keys('error');
+        expect(record).to.contain.keys('message');
+        expect(record.message).to.contain('Not Found');
         done();
       });
     });


### PR DESCRIPTION
PR for #45 

Hook functions now return directly or a promise that resolves to `context.continue`, `context.skip`, `context.stop` to perform those actions.

Errors are no longer handled by setting context.error and passing it along the chain. Any errors thrown in the hook are caught (and stops execution of hooks) and rendered to the client. If it is a subclass of EpilogueError then it will render as the following JSON with the status code `err.status`. 

```
{
  "message": err.message,
  "errors": err.errors // is array
}
```

There are a few predefined errors in epilogue.Errors:

BadRequestError - forces HTTP 400
ForbiddenError - forces HTTP 403
NotFoundError - forces HTTP 404

RequestCompleted is a special case and causes no aditional rendering to the client and exits silently.

For situations were error throwing isn't possible `context.error(err)` is available to call which will resolve the hook and throw the provided error.

### Conversion

This should still support existing use of context apart from error handling. Any code like:

```
res.status(404);
context.error = {
  message: 'not found',
  errors: [ filename ]
};
return context.continue();
```

will need to be rewritten:

```javascript
throw new NotFoundError(null, filename);
```

And any code that checked for the existance of context.error to skip processing should be removed:

```javascript
 if (!!context.error) context.skip();
```