### PR TITLE
Association test - finish beforeEach before starting test.

### DIFF
--- a/tests/resource/associations.test.js
+++ b/tests/resource/associations.test.js
@@ -183,20 +183,17 @@ describe('Resource(associations)', function() {
         }
       ];
 
-      var promise = Promise.resolve();
-      testData.forEach(function(entry) {
-        promise.then(function() {
-          return Promise.all([
-            test.models.User.create(entry.user),
-            test.models.Address.create(entry.address)
-          ]).spread(function(user, address) {
-            var expectedResult = entry.user;
-            expectedResult.id = user.id;
-            expectedResult.address = address.dataValues;
-            test.expectedResults.push(expectedResult);
+      return Promise.resolve(testData).each(function(entry) {
+        return Promise.all([
+          test.models.User.create(entry.user),
+          test.models.Address.create(entry.address)
+        ]).spread(function(user, address) {
+          var expectedResult = entry.user;
+          expectedResult.id = user.id;
+          expectedResult.address = address.dataValues;
+          test.expectedResults.push(expectedResult);
 
-            return user.setAddress(address);
-          });
+          return user.setAddress(address);
         });
       });
     });


### PR DESCRIPTION
The tests were actually starting before the `beforeEach` function was "finished". We just got lucky that the timing worked out.