### PR TITLE
fix(association-belongsToMany)

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -18,7 +18,8 @@ module.exports = function(Resource, resource, association) {
   }
 
   if (!associationPaired) {
-    throw new Error('Paired association can not be found.');
+    // Do not create the resource
+    return;
   }
 
   var associatedResource = new Resource({


### PR DESCRIPTION
Do not throw an error if the paired association does not exist.

If only one belongsToMany association is existent, do not create the new resource because the paired association does not exist.