### PR TITLE
Update nested primkey

### DIFF
--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -3,7 +3,7 @@
 var _ = require('lodash'),
     util = require('util'),
     Base = require('./base'),
-    errors = require('../Errors');
+    ReadController = require('./read');
 
 var Update = function(args) {
   if (args.resource.updateMethod)
@@ -17,26 +17,7 @@ Update.prototype.action = 'update';
 Update.prototype.method = 'put';
 Update.prototype.plurality = 'singular';
 
-Update.prototype.fetch = function(req, res, context) {
-  var model = this.model,
-      endpoint = this.endpoint,
-      criteria = context.criteria || {};
-
-  endpoint.attributes.forEach(function(attribute) {
-    criteria[attribute] = req.params[attribute];
-  });
-
-  return model
-    .find({ where: criteria })
-    .then(function(instance) {
-      if (!instance) {
-        throw new errors.NotFoundError();
-      }
-
-      context.instance = instance;
-      return context.continue;
-    });
-};
+Update.prototype.fetch = ReadController.prototype.fetch;
 
 Update.prototype.write = function(req, res, context) {
   var instance = context.instance;

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -28,9 +28,43 @@ Update.prototype.write = function(req, res, context) {
       context.attributes[a] = req.params[a];
   });
 
+  // Update associated data
+  var self = this,
+      associationPrimKeys = [];
+  if (this.include && this.include.length) {
+    this.include.forEach(function(i) {
+      var primKey = i.model.primaryKeyField,
+          association = _.findWhere(self.model.associations, { target: i.model });
+
+      if (association) {
+        associationPrimKeys.push(association.identifier);
+        if (context.attributes.hasOwnProperty(association.as)) {
+          var attr = context.attributes[association.as];
+
+          if (_.isObject(attr) && attr[primKey]) {
+            context.attributes[association.identifier] = attr[primKey];
+          }
+        }
+      }
+    });
+  }
+
   instance.setAttributes(context.attributes);
+
+  // Check if reload is needed
+  var reloadAfter = !!_.find(associationPrimKeys, function(k) {
+    return instance._changed.hasOwnProperty(k);
+  });
+
   return instance
     .save()
+    .then(function(instance) {
+      if (reloadAfter) {
+        return instance.reload();
+      } else {
+        return instance;
+      }
+    })
     .then(function(instance) {
       context.instance = instance;
       return context.continue;

--- a/tests/resource/associations.test.js
+++ b/tests/resource/associations.test.js
@@ -316,4 +316,52 @@ describe('Resource(associations)', function() {
 
   });
 
+  describe('update', function() {
+    beforeEach(function() {
+      return Promise.all([
+        test.models.Address.create({
+          street: '221B Baker Street',
+          state_province: 'London',
+          postal_code: 'NW1',
+          country_code: '44'
+        }),
+        test.models.User.create({
+          username: 'sherlock',
+          email: 'sherlock@holmes.com'
+        }),
+        test.models.User.create({
+          username: 'watson',
+          email: 'watson@holmes.com'
+        })
+      ]).spread(function(address, user, user2) {
+        return user.setAddress(address);
+      });
+    });
+
+    it('should include associated data', function(done) {
+      request.put({
+        url: test.baseUrl + '/users/1',
+        json: {}
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address).to.be.an('object');
+        expect(result.address.id).to.be.eql(1);
+        done();
+      });
+    });
+
+    it('should not include associated data', function(done) {
+      request.put({
+        url: test.baseUrl + '/usersWithoutInclude/1',
+        json: {}
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address_id).to.exist;
+        expect(result.address_id).to.be.eql(1);
+        done();
+      });
+    });
+
+  });
+
 });

--- a/tests/resource/associations.test.js
+++ b/tests/resource/associations.test.js
@@ -325,6 +325,12 @@ describe('Resource(associations)', function() {
           postal_code: 'NW1',
           country_code: '44'
         }),
+        test.models.Address.create({
+          street: 'Avenue de l\'Atomium',
+          state_province: 'Brussels',
+          postal_code: '1020',
+          country_code: '32'
+        }),
         test.models.User.create({
           username: 'sherlock',
           email: 'sherlock@holmes.com'
@@ -333,7 +339,7 @@ describe('Resource(associations)', function() {
           username: 'watson',
           email: 'watson@holmes.com'
         })
-      ]).spread(function(address, user, user2) {
+      ]).spread(function(address, address2, user, user2) {
         return user.setAddress(address);
       });
     });
@@ -358,6 +364,34 @@ describe('Resource(associations)', function() {
         var result = _.isObject(body) ? body : JSON.parse(body);
         expect(result.address_id).to.exist;
         expect(result.address_id).to.be.eql(1);
+        done();
+      });
+    });
+
+    it('should include the new associated data', function(done) {
+      request.put({
+        url: test.baseUrl + '/users/1',
+        json: {
+          address_id: 2
+        }
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address).to.be.an('object');
+        expect(result.address.id).to.be.eql(2);
+        done();
+      });
+    });
+
+    it('should include the new associated data by identifier of object nested', function(done) {
+      request.put({
+        url: test.baseUrl + '/users/1',
+        json: {
+          address: { id: 2 }
+        }
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address).to.be.an('object');
+        expect(result.address.id).to.be.eql(2);
         done();
       });
     });


### PR DESCRIPTION
This is an improvement over the other MR #67 

-  Controller `update` use the controller `read` to return data. (More logical)  
@mbroadst : Controller `read` and `list` are unmodified. They always returned the associated data if this is defined on resource.
- Allow change associated object based on nested identifier
![capture d ecran 2015-06-04 a 15 57 07](https://cloud.githubusercontent.com/assets/3214565/7985637/6c0f184e-0ad2-11e5-9677-f3046c62a920.png)
- Reload the instance before send it if needed
- I think this is not a breaking change because the identifier is present like before this feature.
