### PR TITLE
Force include to always have a model property

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -18,7 +18,9 @@ var Resource = function(options) {
   this.app = options.app;
   this.sequelize = options.sequelize;
   this.model = options.model;
-  this.include = options.include;
+  this.include = options.include.map(function(include) {
+    return include instanceof options.sequelize.Model ? { model: include } : include;
+  });
   this.actions = options.actions;
   this.endpoints = {
     plural: options.endpoints.shift(),

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -100,6 +100,28 @@ describe('Resource(basic)', function() {
 
       expect(resource.endpoints).to.eql({ plural: '/people', singular: '/people/:id' });
     });
+
+    it('should always transform includes to be objects with a model property', function() {
+      var modelWithAssociation = test.models.Person = test.db.define('modelWithAssociation', {
+        id: { type: test.Sequelize.INTEGER, autoIncrement: true, primaryKey: true }
+      });
+      modelWithAssociation.belongsTo(test.models.User);
+      var resourceWithIncludeAsObject = rest.resource({
+        model: test.models.Person,
+        endpoints: ['/modelwithincludeobject', '/modelwithincludeobject/:id'],
+        include:[{ model: test.models.User }]
+      });
+
+      expect(resourceWithIncludeAsObject.include).to.eql([{ model: test.models.User }]);
+
+      var resourceWithIncludeAsArray = rest.resource({
+        model: test.models.Person,
+        endpoints: ['/modelwithincludearray', '/modelwithincludearray/:id'],
+        include: [test.models.User]
+      });
+
+      expect(resourceWithIncludeAsArray.include).to.eql([{ model: test.models.User }]);
+    });
   });
 
   describe('create', function() {


### PR DESCRIPTION
With implementations dealing with associations under development, it would be a good idea to normalize the structure of `Resource.include`. This change forces includes to always be an array of objects that, at the very least, have a `model` property. This way we won't have to inspect includes all over the place.

This *may* break backwards compatibility if somebody is manipulating an include in their middleware and expects it to be just an array of models, although I haven't seen much evidence that anybody is doing this.

@mbroadst @Fridus