### PR TITLE
Can set an associated object to null

### DIFF
--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -41,8 +41,10 @@ Update.prototype.write = function(req, res, context) {
         if (context.attributes.hasOwnProperty(association.as)) {
           var attr = context.attributes[association.as];
 
-          if (_.isObject(attr) && attr[primKey]) {
+          if (_.isObject(attr) && attr.hasOwnProperty(primKey)) {
             context.attributes[association.identifier] = attr[primKey];
+          } else if(context.attributes.hasOwnProperty(association.as) && attr === null) {
+            context.attributes[association.identifier] = null;
           }
         }
       }

--- a/tests/resource/associations.test.js
+++ b/tests/resource/associations.test.js
@@ -396,6 +396,56 @@ describe('Resource(associations)', function() {
       });
     });
 
+    it('should allow updating an association to null by replacing its primary key', function(done) {
+      request.put({
+        url: test.baseUrl + '/users/1',
+        json: {
+          address: { id: 2 }
+        }
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address).to.be.an('object');
+        expect(result.address.id).to.be.eql(2);
+
+        request.put({
+          url: test.baseUrl + '/users/1',
+          json: {
+            address: { id: null }
+          }
+        }, function(error, response, body) {
+          var result = _.isObject(body) ? body : JSON.parse(body);
+          expect(result.address).to.be.null;
+
+          done();
+        });
+      });
+    });
+
+    it('should allow updating an association with null', function(done) {
+      request.put({
+        url: test.baseUrl + '/users/1',
+        json: {
+          address: { id: 2 }
+        }
+      }, function(error, response, body) {
+        var result = _.isObject(body) ? body : JSON.parse(body);
+        expect(result.address).to.be.an('object');
+        expect(result.address.id).to.be.eql(2);
+
+        request.put({
+          url: test.baseUrl + '/users/1',
+          json: {
+            address: null
+          }
+        }, function(error, response, body) {
+          var result = _.isObject(body) ? body : JSON.parse(body);
+          expect(result.address).to.be.null;
+
+          done();
+        });
+      });
+    });
+
   });
 
 });


### PR DESCRIPTION
Ex:  
`PUT` to `localhost:9000/tasks/4` :
```
{
    "project": {"id": null }
}
```
or
```
{
    "project": null
}
```

Result
```
{
"id": 4,
"title": "Task 4",
"description": "... 4",
"deadline": null,
"createdAt": "2015-06-09T13:22:16.761Z",
"updatedAt": "2015-06-09T13:22:19.142Z",
"projectId": null,
"project": null
}
```