### PR TITLE
Adds default sort criteria

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,26 @@ This would restrict sorting to only the ```username``` attribute of the User mod
 $ curl http://localhost/users?orderby=username
 ```
 
+Default sort criteria can be defined with the `default` attribute. The expected format for default sort criteria is exactly the same as if it was proceeding the `sort` parameter in the URL.
+
+```javascript
+var users = rest.resource({
+    model: User,
+    endpoints: ['/users', '/users/:id'],
+    sort: {
+      default: '-email,username'
+    }
+});
+```
+With this configuration, these two calls would result in the same data:
+
+```bash
+$ curl http://localhost/users
+$ curl http://localhost/users?sort=-email,username
+```
+
+Note that the `sort` parameter in the URL will override your default criteria.
+
 By default all attributes defined on the model are allowed to be sorted on. Sorting on a attribute not allowed will cause a 400 error to be returned with errors in the format:
 
 ```bash

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -55,10 +55,11 @@ List.prototype.fetch = function(req, res, context) {
   }
 
   var sortParam = this.resource.sort.param;
-  if (_.has(req.query, sortParam)) {
+  if (_.has(req.query, sortParam) || _.has(this.resource.sort, 'default')) {
     var order = [];
     var columnNames = [];
-    var sortColumns = req.query[sortParam].split(',');
+    var sortQuery = req.query[sortParam] || this.resource.sort.default || '';
+    var sortColumns = sortQuery.split(',');
     sortColumns.forEach(function(sortColumn) {
       if (sortColumn.indexOf('-') === 0) {
         var actualName = sortColumn.substring(1);

--- a/tests/resource/sort.test.js
+++ b/tests/resource/sort.test.js
@@ -115,6 +115,48 @@ describe('Resource(sort)', function() {
     });
   });
 
+  it('should sort with default sort criteria', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        default: "email"
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) {
+        return _.omit(r, 'id');
+      });
+      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      done();
+    });
+  });
+
+  it('should sort with query overriding default sort criteria', function(done) {
+    rest.resource({
+      model: test.models.User,
+      endpoints: ['/users', '/users/:id'],
+      sort: {
+        default: "-email"
+      }
+    });
+
+    request.get({
+      url: test.baseUrl + '/users?sort=username'
+    }, function(err, response, body) {
+      expect(response.statusCode).to.equal(200);
+      var records = JSON.parse(body).map(function(r) {
+        return _.omit(r, 'id');
+      });
+      expect(records).to.eql(_.sortByAll(test.userlist, ['username']));
+      done();
+    });
+  });
+
   it('should fail sorting with a restricted attribute', function(done) {
     rest.resource({
       model: test.models.User,


### PR DESCRIPTION
Adds default sort criteria, defined by the `default` attribute in `sort` options. 

```javascript
var users = rest.resource({
    model: User,
    endpoints: ['/users', '/users/:id'],
    sort: {
      default: '-email,username'
    }
});
```
This makes...
```bash
$ curl http://localhost/users
```
...functionally equivalent to:
```bash
$ curl http://localhost/users?sort=-email,username
```