### PR TITLE
fix(search): Fulltext search against filtered results

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -95,12 +95,8 @@ List.prototype.fetch = function(req, res, context) {
     return result;
   }, {});
 
-  if (Object.keys(extraSearchCriteria).length) {
-    if (Object.keys(criteria).length)
-      criteria = Sequelize.and(criteria, Sequelize.or.apply(null, [extraSearchCriteria]));
-    else
-      criteria = Sequelize.or.apply(null, [extraSearchCriteria]);
-  }
+  if (Object.keys(extraSearchCriteria).length)
+    criteria = _.assign(criteria, extraSearchCriteria);
 
   // do the actual lookup
   if (Object.keys(criteria).length)

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -95,8 +95,12 @@ List.prototype.fetch = function(req, res, context) {
     return result;
   }, {});
 
-  if (Object.keys(extraSearchCriteria).length)
-    criteria = _.assign(extraSearchCriteria, criteria);
+  if (Object.keys(extraSearchCriteria).length) {
+    if (Object.keys(criteria).length)
+      criteria = Sequelize.and(criteria, Sequelize.or.apply(null, [extraSearchCriteria]));
+    else
+      criteria = Sequelize.or.apply(null, [extraSearchCriteria]);
+  }
 
   // do the actual lookup
   if (Object.keys(criteria).length)

--- a/tests/resource/search.test.js
+++ b/tests/resource/search.test.js
@@ -114,6 +114,12 @@ describe('Resource(search)', function() {
         { username: 'henry', email: 'henry@gmail.com' },
         { username: 'edward', email: 'edward@gmail.com' },
         { username: 'arthur', email: 'aaaaarthur@gmail.com' }]
+    },
+    {
+      name: 'in combination with filtered results',
+      config: {},
+      query: 'aaaa&username=arthur',
+      expectedResults: [{ username: 'arthur', email: 'aaaaarthur@gmail.com' }]
     }
   ].forEach(function(testCase) {
 


### PR DESCRIPTION
I noticed that if the search parameter is used on "list" routes in combination with field-specific filters (think: `GET /employees?gender=male&q=steve`, it errors out with:
```JSON
{
    "message": "internal error",
    "errors": [
        "column Employee.args does not exist"
    ]
}
```
In this case, the `where` criteria isn't being built quite right in [list.js](https://github.com/dchester/epilogue/blob/master/lib/Controllers/list.js#L99). I've adjusted this and added a new test case.
