### PR TITLE
Replace merge-defaults with lodash defaultsDeep

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -4,16 +4,19 @@ var Controllers = require('./Controllers'),
     _ = require('lodash');
 
 var Resource = function(options) {
-  options = _.defaults(options, {
+  _.defaults(options, {
     actions: ['create', 'read', 'update', 'delete', 'list'],
     pagination: true,
+    reloadInstances: true
+  });
+
+  _.defaultsDeep(options, {
     search: {
       param: 'q'
     },
     sort: {
       param: 'sort'
-    },
-    reloadInstances: true
+    }
   });
 
   this.app = options.app;

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,11 +4,7 @@ var Resource = require('./Resource'),
     Endpoint = require('./Endpoint'),
     Controllers = require('./Controllers'),
     Errors = require('./Errors'),
-    inflection = require('inflection'),
-    _ = require('lodash');
-
-// make deep defaults the default
-_.defaults = require('merge-defaults');
+    inflection = require('inflection');
 
 var epilogue = {
   initialize: function(args) {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
   "dependencies": {
     "bluebird": "^2.9.34",
     "inflection": "^1.7.1",
-    "lodash": "^3.10.1",
-    "merge-defaults": "^0.2.1"
+    "lodash": "^3.10.1"
   },
   "devDependencies": {
     "body-parser": "^1.13.3",


### PR DESCRIPTION
Removed merge-defaults as dependency.
[defaultsDeep](https://lodash.com/docs#defaultsDeep) also merges arrays, that's not desirable, so used defaults too.
Both methods mutates the object in 1st argument, no need to assign it to the variable.