### PR TITLE
Add support for altering base query options via context.options

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -89,7 +89,8 @@ Controller.prototype._control = function(req, res) {
       context = {
         instance: undefined,
         criteria: {},
-        attributes: {}
+        attributes: {},
+        options: {}
       };
 
   Controller.milestones.forEach(function(milestone) {

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -2,7 +2,7 @@
 
 var util = require('util'),
     Base = require('./base'),
-    errors = require('../Errors');
+    ReadController = require('./read');
 
 var Delete = function(args) {
   Delete.super_.call(this, args);
@@ -14,26 +14,7 @@ Delete.prototype.action = 'delete';
 Delete.prototype.method = 'delete';
 Delete.prototype.plurality = 'singular';
 
-Delete.prototype.fetch = function(req, res, context) {
-  var model = this.model,
-      endpoint = this.endpoint,
-      criteria = context.criteria || {};
-
-  endpoint.attributes.forEach(function(attribute) {
-    criteria[attribute] = req.params[attribute];
-  });
-
-  return model
-    .find({ where: criteria })
-    .then(function(instance) {
-      if (!instance) {
-        throw new errors.NotFoundError();
-      }
-
-      context.instance = instance;
-      return context.continue;
-    });
-};
+Delete.prototype.fetch = ReadController.prototype.fetch;
 
 Delete.prototype.write = function(req, res, context) {
   return context.instance

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -18,6 +18,7 @@ List.prototype.plurality = 'plural';
 
 List.prototype.fetch = function(req, res, context) {
   var model = this.model,
+      options = context.options || {},
       criteria = context.criteria || {},
       include = this.include,
       includeAttributes = this.includeAttributes,
@@ -30,7 +31,8 @@ List.prototype.fetch = function(req, res, context) {
   if (count > 1000) count = 1000;
   if (count < 0) count = defaultCount;
 
-  var options = { offset: offset, limit: count };
+  options.offset = offset;
+  options.limit = count;
   if (!this.resource.pagination)
     delete options.limit;
 

--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -17,10 +17,10 @@ Read.prototype.plurality = 'singular';
 Read.prototype.fetch = function(req, res, context) {
   var model = this.model,
       endpoint = this.endpoint,
+      options = context.options || {},
       criteria = context.criteria || {},
       include = this.include,
-      includeAttributes = this.includeAttributes || [],
-      options = {};
+      includeAttributes = this.includeAttributes || [];
 
   endpoint.attributes.forEach(function(attribute) {
     if (attribute in req.params) {

--- a/tests/milestones/milestones.test.js
+++ b/tests/milestones/milestones.test.js
@@ -532,6 +532,31 @@ describe('Milestones', function() {
         });
       });
     });
+
+    it('should support custom options for before fetch', function(done) {
+      var expected = { username: 'jamez' };
+      test.userResource.read.fetch.before(function(req, res, context) {
+        context.options.attributes = ['username'];
+        return context.continue;
+      });
+
+      request.post({
+        url: test.baseUrl + '/users',
+        json: {username: 'jamez', email: 'jamez@gmail.com' }
+      }, function(err, response, body) {
+        expect(err).to.be.null;
+        expect(response.statusCode).to.equal(201);
+
+        var path = response.headers.location;
+        request.get({ url: test.baseUrl + path }, function(err, response, body) {
+          var record = _.isObject(body) ? body : JSON.parse(body);
+          delete record.id;
+          expect(response.statusCode).to.equal(200);
+          expect(record).to.eql(expected);
+          done();
+        });
+      });
+    });
   });
 
   describe('data', function() {


### PR DESCRIPTION
This patch adds access to the `context.options` object before the fetch milestone, which allows the user to pass in custom query options before the find query is executed.

This is useful for a variety of reasons, allowing users to alter base sequelize query options like `attributes` or `transaction` and `lock`, but will also allow for more flexible integration with custom sequelize addons that may add other custom query options.

Offering similar options for create/update/delete in the future would likely be a good idea, but this patch simply only adds it for the read/list actions.