### PR TITLE
Fix bug on search attributes type checking

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -51,8 +51,8 @@ List.prototype.fetch = function(req, res, context) {
       this.resource.search.attributes || Object.keys(model.rawAttributes);
     searchAttributes.forEach(function(attr) {
       var attrType = model.rawAttributes[attr].type;
-      if (!(attrType instanceof Sequelize.STRING) &&
-          !(attrType instanceof Sequelize.TEXT)) {
+      if (!(attrType instanceof Sequelize.Sequelize.STRING) &&
+          !(attrType instanceof Sequelize.Sequelize.TEXT)) {
         // NOTE: Sequelize has added basic validation on types, so we can't get
         //       away with blind comparisons anymore. The feature is up for
         //       debate so this may be changed in the future


### PR DESCRIPTION
Hy, 

There is a bug on search since 08683277748a1739833be4d7293ef8731f35ca06 : the check if attributes are either STRING or TEXT is done against `undefined`.