### PR TITLE
Change associations endpoints to hyphen style

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -5,7 +5,7 @@ var _ = require('lodash');
 module.exports = function(Resource, resource, association) {
   // access points
   var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+    association.target.options.name.plural.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
   // Find reverse association
   var associationPaired;

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -3,7 +3,7 @@
 module.exports = function(Resource, resource, association) {
   // access points
   var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+    association.target.options.name.singular.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -3,7 +3,7 @@
 module.exports = function(Resource, resource, association) {
   // access points
   var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+    association.target.options.name.plural.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -3,7 +3,7 @@
 module.exports = function(Resource, resource, association) {
   // access points
   var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+    association.target.options.name.singular.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,


### PR DESCRIPTION
Sequelize models use camel/snake case convention where as RESTfull is more hyphen like. I'd suggest making the default associations that way.

There is an alternative. We could make introduce an additional configuration for associations which would allow user to specify the endpoints directly.