### PR TITLE
Only validate field type for *likesearch operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ This would restrict substring searches to the ```username``` attribute of the Us
 $ curl http://localhost/users?searchOnlyUsernames=james
 ```
 
-By default, the substring search is performed using a ```{field} LIKE '%{query}%'``` pattern. However, this behavoir can be customized by specifying a search operator. Valid operators include: `$ne`, `$not`, `$gte`, `$gt`, `$lte`, `$lt`, `$like` (default), `$ilike`/`$iLike`, `$notLike`, `$notILike`. For instance:
+By default, the substring search is performed using a ```{field} LIKE '%{query}%'``` pattern. However, this behavior can be customized by specifying a search operator. Valid operators include: `$like` (default), `$ilike`/`$iLike`, `$notLike`, `$notILike`, `$ne`, `$not`, `$gte`, `$gt`, `$lte`, `$lt`. All "\*like" operators can only be used against Sequelize.STRING or Sequelize.TEXT fields. For instance:
 
 ```javascript
 var users = rest.resource({

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -61,7 +61,7 @@ List.prototype.fetch = function(req, res, context) {
     var searchOperator = this.resource.search.operator || '$like';
     var searchAttributes =
       this.resource.search.attributes || Object.keys(model.rawAttributes);
-    var stringOperators = /like|ilike|iLike|notLike|notILike/;
+    var stringOperators = /like|iLike|notLike|notILike/;
     searchAttributes.forEach(function(attr) {
       if(stringOperators.test(searchOperator)){
         var attrType = model.rawAttributes[attr].type;

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -61,14 +61,23 @@ List.prototype.fetch = function(req, res, context) {
     var searchOperator = this.resource.search.operator || '$like';
     var searchAttributes =
       this.resource.search.attributes || Object.keys(model.rawAttributes);
+    var stringOperators = {
+      "$like": null,
+      "$ilike": null,
+      "$iLike": null,
+      "$notLike": null,
+      "$notILike": null
+    };
     searchAttributes.forEach(function(attr) {
-      var attrType = model.rawAttributes[attr].type;
-      if (!(attrType instanceof Sequelize.STRING) &&
-          !(attrType instanceof Sequelize.TEXT)) {
-        // NOTE: Sequelize has added basic validation on types, so we can't get
-        //       away with blind comparisons anymore. The feature is up for
-        //       debate so this may be changed in the future
-        return;
+      if(searchOperator in stringOperators){
+        var attrType = model.rawAttributes[attr].type;
+        if (!(attrType instanceof Sequelize.STRING) &&
+            !(attrType instanceof Sequelize.TEXT)) {
+          // NOTE: Sequelize has added basic validation on types, so we can't get
+          //       away with blind comparisons anymore. The feature is up for
+          //       debate so this may be changed in the future
+          return;
+        }
       }
 
       var item = {};

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -61,15 +61,9 @@ List.prototype.fetch = function(req, res, context) {
     var searchOperator = this.resource.search.operator || '$like';
     var searchAttributes =
       this.resource.search.attributes || Object.keys(model.rawAttributes);
-    var stringOperators = {
-      "$like": null,
-      "$ilike": null,
-      "$iLike": null,
-      "$notLike": null,
-      "$notILike": null
-    };
+    var stringOperators = /like|ilike|iLike|notLike|notILike/;
     searchAttributes.forEach(function(attr) {
-      if(searchOperator in stringOperators){
+      if(stringOperators.test(searchOperator)){
         var attrType = model.rawAttributes[attr].type;
         if (!(attrType instanceof Sequelize.STRING) &&
             !(attrType instanceof Sequelize.TEXT)) {


### PR DESCRIPTION
I think validation of the field type is only relevant for "like" type search operators. This change allows other field types to be usable with searches by validating Sequelize.TEXT and Sequelize.STRING only if the search operator is in the "like" family. 