### PR TITLE
check sequelize instance on runtime

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@ var Resource = require('./Resource'),
     inflection = require('inflection'),
     _ = require('lodash');
 
+var requiredSequelizeAttrs = ['version', 'and', 'or', 'STRING', 'TEXT'];
+
 var epilogue = {
   initialize: function(options) {
     options = options || {};
@@ -19,6 +21,10 @@ var epilogue = {
     this.app = options.app;
     this.sequelize = (options.sequelize.Sequelize) ?
       options.sequelize.Sequelize : options.sequelize;
+
+    if (!_.every(requiredSequelizeAttrs, _.partial(_.has, this.sequelize)))
+      throw new Error('invalid sequelize instance');
+
     this.base = options.base || '';
     if (options.updateMethod) {
       var method = options.updateMethod.toLowerCase();

--- a/tests/epilogue.test.js
+++ b/tests/epilogue.test.js
@@ -17,10 +17,18 @@ describe('Epilogue', function() {
     done();
   });
 
-  it('should throw an exception with an invalid updateMethod', function(done) {
+  it('should throw an exception when initialized with an invalid sequelize instance', function(done) {
     expect(epilogue.initialize.bind(epilogue, {
       app: {},
       sequelize: {},
+    })).to.throw('invalid sequelize instance');
+    done();
+  });
+
+  it('should throw an exception with an invalid updateMethod', function(done) {
+    expect(epilogue.initialize.bind(epilogue, {
+      app: {},
+      sequelize: {version: 0, STRING:0, TEXT:0, and: 0, or: 0},
       updateMethod: 'dogs'
     })).to.throw('updateMethod must be one of PUT, POST, or PATCH');
     done();
@@ -38,6 +46,10 @@ describe('Epilogue', function() {
       sequelize: db
     });
 
+    // required sequelize parameters for the list searching
     expect(epilogue.sequelize.STRING).to.exist;
+    expect(epilogue.sequelize.TEXT).to.exist;
+    expect(epilogue.sequelize.and).to.exist;
+    expect(epilogue.sequelize.or).to.exist;
   });
 });


### PR DESCRIPTION
In reference to #119, I think I makes sense to check the validity of the Sequelize instance on runtime.

This tiny attribute checking isn't perfect, but it will avoid errors when an invalid sequelize instance is passed to epilogue.