### PR TITLE
Allow not reading associations on read

### DIFF
--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -45,6 +45,10 @@ Read.prototype.fetch = function(req, res, context) {
       return includeAttributes.indexOf(attr) === -1;
     });
   }
+    
+    if(this.resource.associationOptions.doNotReadAssociations){
+        options.include = [];
+    }
 
   return model
     .find(options)


### PR DESCRIPTION
I do not want to, upon `/read` include the associations in the result.

This gives the option for this to happen.