### PR TITLE
Fix hardcoded target primary key field name

### DIFF
--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -29,7 +29,7 @@ module.exports = function(Resource, resource, association) {
     endpoints: [
       resource.endpoints.singular + '/' + subResourceName,
       resource.endpoints.plural + '/:' + associationPaired.foreignIdentifierField + '/' +
-        subResourceName + '/:id'
+        subResourceName + '/:' + association.target.primaryKeyField
     ],
     actions: ['read', 'list']
   });
@@ -56,7 +56,7 @@ module.exports = function(Resource, resource, association) {
   associatedResource.list.fetch.before(function(req, res, context) {
     // Filter
     var where = {};
-    where[association.source.primaryKeyField] = req.params.id;
+    where[association.source.primaryKeyField] = req.params[association.target.primaryKeyField];
 
     context.include = context.include || [];
     context.include.push({

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -11,7 +11,7 @@ module.exports = function(Resource, resource, association) {
     model: association.target,
     endpoints: [
       resource.endpoints.plural + '/:' + association.identifierField + '/' + subResourceName,
-      resource.endpoints.plural + '/:' + association.identifierField + '/' + subResourceName + '/:id'
+      resource.endpoints.plural + '/:' + association.identifierField + '/' + subResourceName + '/:' + association.target.primaryKeyField
     ],
     actions: ['read', 'list']
   });


### PR DESCRIPTION
Use association.target.primaryKeyField to set the name of the target primary key field rather than 'id'.