### PR TITLE
Omit assocition, if autoPopulate is set to false

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -168,10 +168,12 @@ function autoAssociate(resource) {
 
   _.forEach(resource.model.associations, function(association) {
     // for prefetched data in list and read
-    if (!!association.as) {
-      resource.include.push({ model: association.target, as: association.as });
-    } else {
-      resource.include.push(association.target);
+    if (!_.has(resource.associationOptions, 'autoPopulate') || !!resource.associationOptions.autoPopulate) {
+      if (!!association.as) {
+        resource.include.push({model: association.target, as: association.as});
+      } else {
+        resource.include.push(association.target);
+      }
     }
 
     var subResourceName;


### PR DESCRIPTION
If the resource's `autoPopulate` option is explicitly set to `false`, it will not be added to the include list