### PR TITLE
Add epilogue.initialize([options.resource])

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,11 +34,18 @@ var epilogue = {
 
       this.updateMethod = method;
     }
+
+    this.defaultOptions = {
+      resource: {}
+    };
+    if (options.resource) {
+      this.defaultOptions.resource = options.resource;
+    }
   },
 
   resource: function(options) {
     options = options || {};
-    _.defaults(options, {
+    _.defaults(options, this.defaultOptions.resource, {
       include: [],
       associations: false
     });

--- a/tests/epilogue.test.js
+++ b/tests/epilogue.test.js
@@ -34,6 +34,22 @@ describe('Epilogue', function() {
     done();
   });
 
+  it('should extend .resource options if they are provided on initialize', function() {
+    var resourceOptions = { pagination: false };
+
+    epilogue.initialize({
+      app: {},
+      sequelize: new Sequelize('main', null, null, {
+        dialect: 'sqlite',
+        storage: ':memory:',
+        logging: (process.env.SEQ_LOG ? console.log : false)
+      }),
+      resource: resourceOptions
+    });
+
+    expect(epilogue.defaultOptions.resource).to.be.equal(resourceOptions);
+  });
+
   it('should allow the user to pass in a sequelize instance rather than prototype', function() {
     var db = new Sequelize('main', null, null, {
       dialect: 'sqlite',

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -89,7 +89,16 @@ describe('Resource(basic)', function() {
         expect(exception).to.eql(new Error('resource needs a model'));
         done();
       }
+    });
 
+    it('should extend default options', function() {
+      rest.defaultOptions.resource = { pagination: false };
+
+      var resource = rest.resource({
+        model: test.models.Person
+      });
+
+      expect( resource.pagination ).to.be.equal( false );
     });
 
     it('should auto generate endpoints if none were provided', function() {


### PR DESCRIPTION
This PR adds the `resource` option on `epilogue.initialize` that allows a definition of default `options` properties for the further `epilogue.resource` calls.