### PR TITLE
Upgrade lodash@4.8.2

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -24,7 +24,7 @@ Controller.prototype.initialize = function(options) {
     });
 
     _.forEach(this.model.associations, function(association) {
-      if (_.contains(includeModels, association.target))
+      if (_.includes(includeModels, association.target))
         includeAttributes.push(association.identifier);
     });
     this.includeAttributes = includeAttributes;

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -12,7 +12,7 @@ module.exports = function(Resource, resource, association) {
   if (association.paired) {
     associationPaired = _.find(association.target.associations, association.paired);
   } else {
-    associationPaired = _.findWhere(association.target.associations, {
+    associationPaired = _.find(association.target.associations, {
       paired: association
     });
   }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "bluebird": "^3.0.0",
     "inflection": "^1.7.1",
-    "lodash": "^3.10.1"
+    "lodash": "^4.8.2"
   },
   "devDependencies": {
     "body-parser": "^1.13.3",

--- a/tests/resource/sort.test.js
+++ b/tests/resource/sort.test.js
@@ -61,7 +61,7 @@ describe('Resource(sort)', function() {
         var records = JSON.parse(body).map(function(r) {
           return _.omit(r, 'id');
         });
-        expect(records).to.eql(_.sortByAll(test.userlist, ['username']));
+        expect(records).to.eql(_.sortBy(test.userlist, ['username']));
         done();
     });
   });
@@ -82,7 +82,7 @@ describe('Resource(sort)', function() {
       var records = JSON.parse(body).map(function(r) {
         return _.omit(r, 'id');
       });
-      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      expect(records).to.eql(_.sortBy(test.userlist, ['email']));
       done();
     });
   });
@@ -103,7 +103,7 @@ describe('Resource(sort)', function() {
       var records = JSON.parse(body).map(function(r) {
         return _.omit(r, 'id');
       });
-      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      expect(records).to.eql(_.sortBy(test.userlist, ['email']));
       done();
     });
   });
@@ -124,7 +124,7 @@ describe('Resource(sort)', function() {
       var records = JSON.parse(body).map(function(r) {
         return _.omit(r, 'id');
       });
-      expect(records).to.eql(_.sortByAll(test.userlist, ['email']));
+      expect(records).to.eql(_.sortBy(test.userlist, ['email']));
       done();
     });
   });
@@ -145,7 +145,7 @@ describe('Resource(sort)', function() {
       var records = JSON.parse(body).map(function(r) {
         return _.omit(r, 'id');
       });
-      expect(records).to.eql(_.sortByAll(test.userlist, ['username']));
+      expect(records).to.eql(_.sortBy(test.userlist, ['username']));
       done();
     });
   });


### PR DESCRIPTION
Breaking changes from Lodash:
https://github.com/lodash/lodash/wiki/Changelog#v400
- Removed _.findWhere in favor of _.find with iteratee shorthand
- Absorbed _.sortByAll into _.sortBy