### PR TITLE
Make "npm run coverage" work well in both windows 7 and linux.

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "jshint": "jshint ./lib ./tests",
     "mocha": "mocha --check-leaks -R spec -u exports tests/*.test.js tests/**/*.test.js",
-    "coverage": "istanbul cover node_modules/.bin/_mocha -- -- tests/*.test.js tests/**/*.test.js",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- tests/*.test.js tests/**/*.test.js",
     "test": "npm run-script jshint && npm run-script mocha"
   },
   "repository": {


### PR DESCRIPTION
# "npm run coverage" worked bad in windows 7 system and need a fix

The fix will make it work well in both win7 and linux system