### PR TITLE
Bug fix for update controller with excludeAttribute response

### DIFF
--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -57,10 +57,22 @@ Update.prototype.write = function(req, res, context) {
     .save()
     .then(function(instance) {
       if (reloadAfter) {
-        return instance.reload({ include: self.include });
+        var reloadOptions = {};
+        if (Array.isArray(self.include) && self.include.length)
+          reloadOptions.include=self.include;
+        if (!!self.resource.excludeAttributes)
+          reloadOptions.attributes = {exclude: self.resource.excludeAttributes };   
+        return instance.reload(reloadOptions);
       } else {
         return instance;
       }
+    }).then(function (instance) { 
+      if (!!self.resource.excludeAttributes) {
+        self.resource.excludeAttributes.forEach(function(attr) {
+          delete instance.dataValues[attr];
+        });
+      }
+      return instance;
     })
     .then(function(instance) {
       if (self.resource.associationOptions.removeForeignKeys) {

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -402,6 +402,25 @@ describe('Resource(basic)', function() {
       });
     });
 
+    it('should reload instance on update, excluding selected attrs', function(done) {
+      var userData = { username: 'arthur', email: 'jamez@gmail.com' };
+      request.post({
+        url: test.baseUrl + '/usersWithExclude',
+        json: userData
+      }, function(error, response, body) {
+        expect(error).is.null;
+        expect(response.headers.location).is.not.empty;
+       var path = response.headers.location;
+         request.put({
+          url: test.baseUrl + path,
+          json: { email: 'emma@fmail.co.uk' }
+        }, function(err, response, body) {
+          expect(response.statusCode).to.equal(200);
+          expect(body).to.eql({ id: 1, username: 'arthur' });
+          done();
+      });
+    });
+  });
   });
 
   describe('delete', function() {


### PR DESCRIPTION
**Added support of `excludeAttributes:[]` into `update` controller.**

I followed the same approach as  in `create` controller.

**Scenario to handle:**

When updating a user record that has a password we certainly do not want to see salt and password-hash in responses from server.

====================================
I suppose that's another hotfix before rethinking  this approach.
Thank you