### PR TITLE
Remove hard limit of 1000 on query

### DIFF
--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -41,7 +41,6 @@ List.prototype.fetch = function(req, res, context) {
 
   // account for offset and count
   offset += context.page * count || req.query.page * count || 0;
-  if (count > 1000) count = 1000;
   if (count < 0) count = defaultCount;
 
   options.offset = offset;


### PR DESCRIPTION
As we had discovered, there is a hard limit of 1000, overriding count parameter that is passed into the context.  I have removed it.