### PR TITLE
added support for scopes for 'read' endpoints

### DIFF
--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -46,6 +46,10 @@ Read.prototype.fetch = function(req, res, context) {
     });
   }
 
+  if (req.query.scope) {
+    model = model.scope(req.query.scope);
+  }
+
   return model
     .find(options)
     .then(function(instance) {

--- a/tests/resource/resource.test.js
+++ b/tests/resource/resource.test.js
@@ -24,7 +24,14 @@ describe('Resource(basic)', function() {
     }, {
       underscored: true,
       timestamps: false,
-      hooks: {
+      scopes: {
+        userNameStartsWithA: {
+          where: {
+            username: { $like: 'a%' }
+          }
+        }
+      },
+       hooks: {
         beforeFind: function(options) {
           if (this.enableBrokenFindTest) {
             this.enableBrokenFindTest = false;
@@ -690,6 +697,22 @@ describe('Resource(basic)', function() {
 
       return Promise.all(promises);
     });
+
+    it('should support scope to return a data subset', function(done) {
+      request.get({
+        url: test.baseUrl + '/users?scope=userNameStartsWithA'
+      }, function(err, response, body) {
+        expect(response.statusCode).to.equal(200);
+        var records = JSON.parse(body).map(function(r) { delete r.id; return r; });
+        expect(records).to.eql([
+          { username: 'arthur', email: 'arthur@gmail.com' },
+          { username: 'arthur', email: 'aaaaarthur@gmail.com' }
+        ]);
+        done();
+      });
+    });
+
+
 
   });
 


### PR DESCRIPTION
Needed a support for Sequelize scopes also in case of read operations.
May be useful in some cases - e.g. we have used it to steer what set of includes we get. 