### PR TITLE
Support sequelize options through context.sequelizeOptions

### DIFF
--- a/lib/Controllers/create.js
+++ b/lib/Controllers/create.js
@@ -33,9 +33,9 @@ Create.prototype.write = function(req, res, context) {
   }
 
   return this.model
-    .create(context.attributes, {
+    .create(context.attributes, Object.assign({
       include: this.include
-    })
+    }, context.sequelizeOptions))
     .then(function(instance) {
       if (self.resource) {
         var endpoint = self.resource.endpoints.singular;

--- a/lib/Controllers/delete.js
+++ b/lib/Controllers/delete.js
@@ -18,7 +18,7 @@ Delete.prototype.fetch = ReadController.prototype.fetch;
 
 Delete.prototype.write = function(req, res, context) {
   return context.instance
-    .destroy()
+    .destroy(context.sequelizeOptions)
     .then(function() {
       context.instance = {};
       return context.continue;

--- a/lib/Controllers/list.js
+++ b/lib/Controllers/list.js
@@ -150,7 +150,7 @@ List.prototype.fetch = function(req, res, context) {
   }
 
   return model
-    .findAndCountAll(options)
+    .findAndCountAll(Object.assign(options, context.sequelizeOptions))
     .then(function(result) {
       context.instance = result.rows;
       var start = offset;

--- a/lib/Controllers/read.js
+++ b/lib/Controllers/read.js
@@ -51,7 +51,7 @@ Read.prototype.fetch = function(req, res, context) {
   }
 
   return model
-    .find(options)
+    .find(Object.assign(options, context.sequelizeOptions))
     .then(function(instance) {
       if (!instance) {
         throw new errors.NotFoundError();

--- a/lib/Controllers/update.js
+++ b/lib/Controllers/update.js
@@ -54,7 +54,7 @@ Update.prototype.write = function(req, res, context) {
     });
 
   return instance
-    .save()
+    .save(context.sequelizeOptions)
     .then(function(instance) {
       if (reloadAfter) {
         var reloadOptions = {};


### PR DESCRIPTION
Hi,

We've been running with this fork for a year and though that this might interest someone.

We've added an attribute (`sequelizeOptions`) to epilogue context to specify options to sequelize `find`, `create`, `update` or `destroy` methods.

This is useful for enforcing attribute/model access control with sequelize hooks (with something that looks like [ssacl-attribute-roles](https://github.com/mickhansen/ssacl-attribute-roles)), or to easily dispatch "changes" somewhere else : 

In epilogue resources declaration:

```javascript
const passRequestToSequelize = {
  write: {
    before: function(request, response, context) {
      context.sequelizeOptions = {
        _request: request,
      };
      return context.continue;
    }
  }
};

export const changelog = {
  create: passRequestToSequelize,
  update: passRequestToSequelize,
  delete: passRequestToSequelize,
};

// ...

epilogueResource.use(changelog);
```

In sequelize initialization:

```javascript
function customLog(type, instance, options) {
  const changes = instance.changed();
  logEvent({
    type: type,
    model: instance.Model,
    changes: changes ? changes.map(k => instance.previous(k)) : false,
    userId: options._request.currentUser.id
  })
}

const sequelize = new Sequelize('postgres://user:pass@example.com:5432/dbname', config);

sequelize.addHook('afterCreate', customLog.bind(null, 'create'));
sequelize.addHook('afterUpdate', customLog.bind(null, 'update'));
sequelize.addHook('afterDestroy', customLog.bind(null, 'delete'));
```

What do you think ?

Thanks for epilogue !