### PR TITLE
Fix check of restify vs express

### DIFF
--- a/lib/Controllers/base.js
+++ b/lib/Controllers/base.js
@@ -70,7 +70,8 @@ Controller.prototype.route = function() {
       self = this;
 
   // NOTE: is there a better place to do this mapping?
-  if (app.name === 'restify' && self.method === 'delete')
+  // Map Express `app.delete` to Restify `app.del`
+  if (self.method === 'delete' && app[self.method] === undefined)
     self.method = 'del';
 
   app[self.method](endpoint.string, function(req, res) {


### PR DESCRIPTION
Restify's `createServer` method [allows a `name` option](http://restify.com/docs/server-api/) to customize the server name.

If it's value is changed from `"restify"`, the following check would think it's running under Express:
https://github.com/dchester/epilogue/blob/d46def3dfc7b9dd7b25303b124bb337499cc9f1f/lib/Controllers/base.js#L73-L74

And then the server would crash because `app.delete is not a function` in Restify.

This PR takes a safer approach by simply checking if `app.delete` is `undefined`.