### PR TITLE
associations: subResourceName is set by association.as if available

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -224,21 +224,25 @@ function autoAssociate(resource) {
 
     var subResourceName;
     if (association.associationType === 'HasOne') {
-      subResourceName =
+      subResourceName = !!association.as ?
+        association.as :
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = hasOneResource(Resource, resource, association);
     } else if (association.associationType === 'HasMany') {
-      subResourceName =
+      subResourceName = !!association.as ?
+        association.as :
         association.target.options.name.plural.toLowerCase();
       resource[subResourceName] = hasManyResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsTo') {
-      subResourceName =
+      subResourceName = !!association.as ?
+        association.as :
         association.target.options.name.singular.toLowerCase();
       resource[subResourceName] = belongsToResource(Resource, resource, association);
     } else if (association.associationType === 'BelongsToMany') {
-     subResourceName =
-       association.target.options.name.plural.toLowerCase();
-     resource[subResourceName] = belongsToManyResource(Resource, resource, association);
+      subResourceName = !!association.as ?
+        association.as :
+        association.target.options.name.plural.toLowerCase();
+      resource[subResourceName] = belongsToManyResource(Resource, resource, association);
     }
   });
 }

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -4,14 +4,9 @@ var _ = require('lodash');
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName;
-
-  if (!!association.as) {
-    subResourceName = association.as;
-  }
-  else {
-    subResourceName = association.target.options.name.plural.toLowerCase();
-  }
+  var subResourceName = !!association.as ?
+      association.as :
+      association.target.options.name.plural.toLowerCase();
 
   // Find reverse association
   var associationPaired;

--- a/lib/associations/belongs-to-many.js
+++ b/lib/associations/belongs-to-many.js
@@ -4,8 +4,14 @@ var _ = require('lodash');
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName;
+
+  if (!!association.as) {
+    subResourceName = association.as;
+  }
+  else {
+    subResourceName = association.target.options.name.plural.toLowerCase();
+  }
 
   // Find reverse association
   var associationPaired;

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -2,14 +2,9 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName;
-
-  if (!!association.as) {
-    subResourceName = association.as;
-  }
-  else {
-    subResourceName = association.target.options.name.singular.toLowerCase();
-  }
+  var subResourceName = !!association.as ?
+      association.as :
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/belongs-to.js
+++ b/lib/associations/belongs-to.js
@@ -2,8 +2,14 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName;
+
+  if (!!association.as) {
+    subResourceName = association.as;
+  }
+  else {
+    subResourceName = association.target.options.name.singular.toLowerCase();
+  }
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -2,14 +2,9 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName;
-
-  if (!!association.as) {
-    subResourceName = association.as;
-  }
-  else {
-    subResourceName = association.target.options.name.plural.toLowerCase();
-  }
+  var subResourceName = !!association.as ?
+      association.as :
+      association.target.options.name.plural.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-many.js
+++ b/lib/associations/has-many.js
@@ -2,8 +2,14 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.plural.toLowerCase();
+  var subResourceName;
+
+  if (!!association.as) {
+    subResourceName = association.as;
+  }
+  else {
+    subResourceName = association.target.options.name.plural.toLowerCase();
+  }
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -2,14 +2,9 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName;
-
-  if (!!association.as) {
-    subResourceName = association.as;
-  }
-  else {
-    subResourceName = association.target.options.name.singular.toLowerCase();
-  }
+  var subResourceName = !!association.as ?
+      association.as :
+      association.target.options.name.singular.toLowerCase();
 
   var associatedResource = new Resource({
     app: resource.app,

--- a/lib/associations/has-one.js
+++ b/lib/associations/has-one.js
@@ -2,8 +2,14 @@
 
 module.exports = function(Resource, resource, association) {
   // access points
-  var subResourceName =
-    association.target.options.name.singular.toLowerCase();
+  var subResourceName;
+
+  if (!!association.as) {
+    subResourceName = association.as;
+  }
+  else {
+    subResourceName = association.target.options.name.singular.toLowerCase();
+  }
 
   var associatedResource = new Resource({
     app: resource.app,


### PR DESCRIPTION
I think it makes sense to be able to decide what the `subResourceName` of an association is.  For instance, imagine that I have:
```
var Person = sequelize.define('person', { name: { type: DataTypes.STRING } }),
    Course = sequelize.define('course', { name: { type: DataTypes.STRING } });
Course.hasMany(Person, {as: 'students'});
Course.hasOne(Person, { as: 'teacher' });
epilogue.resource({model: Course, 
    endpoints: ['/courses', '/courses/:id'], 
    associations: true});
```
Under the current logic, the association Resources are named according to the model name, inflected for the number of the association.  I think with my example here, we would get `/courses/:id/person` and `/courses/:id/people/`.  Intuitively, though, it seems like we have gone to the trouble of naming the association in the model, and so we should get routes like `/courses/:id/students/` and `/courses/:id/teacher`.

This patch checks the `association.as` field before setting the `subResourceName`.